### PR TITLE
Build as shared library on Windows using Visual Studio compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,13 @@ target_compile_features(json-schema-validator
         cxx_range_for) # for C++11 - flags
 target_compile_options(json-schema-validator
     PUBLIC
-        -Wall -Wextra) # bad, better use something else based on compiler type
+        -Wall) # bad, better use something else based on compiler type
 target_link_libraries(json-schema-validator
     PUBLIC
         json-hpp)
+target_compile_definitions(json-schema-validator
+    PRIVATE
+        -DJSON_SCHEMA_VALIDATOR_EXPORTS)
 
 # regex with boost if gcc < 4.8 - default is std::regex
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -112,6 +115,4 @@ if(JSON_SCHEMA_TEST_SUITE_PATH)
 else()
     message(STATUS "Consider setting JSON_SCHEMA_TEST_SUITE_PATH to a path in which JSON-Schema-Test-Suite is located (github.com/json-schema-org/JSON-Schema-Test-Suite).")
 endif()
-
-
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,12 @@ target_include_directories(json-schema-validator
 target_compile_features(json-schema-validator
     PUBLIC
         cxx_range_for) # for C++11 - flags
-target_compile_options(json-schema-validator
+# Enable more compiler warnings, except when using Visual Studio compiler
+if(NOT MSVC)
+    target_compile_options(json-schema-validator
     PUBLIC
-        -Wall) # bad, better use something else based on compiler type
+        -Wall -Wextra)
+endif()
 target_link_libraries(json-schema-validator
     PUBLIC
         json-hpp)

--- a/app/json-schema-validate.cpp
+++ b/app/json-schema-validate.cpp
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 	json document;
 
 	try {
-        std::cin >> document;
+		std::cin >> document;
 		validator.validate(document);
 	} catch (std::exception &e) {
 		std::cerr << "schema validation failed\n";

--- a/app/json-schema-validate.cpp
+++ b/app/json-schema-validate.cpp
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 	json document;
 
 	try {
-		document << std::cin;
+        std::cin >> document;
 		validator.validate(document);
 	} catch (std::exception &e) {
 		std::cerr << "schema validation failed\n";

--- a/src/json-schema.hpp
+++ b/src/json-schema.hpp
@@ -26,6 +26,16 @@
 #ifndef NLOHMANN_JSON_SCHEMA_HPP__
 #define NLOHMANN_JSON_SCHEMA_HPP__
 
+#ifdef _WIN32
+#    ifdef JSON_SCHEMA_VALIDATOR_EXPORTS
+#        define JSON_SCHEMA_VALIDATOR_API __declspec(dllexport)
+#    else
+#        define JSON_SCHEMA_VALIDATOR_API __declspec(dllimport)
+#    endif
+#else
+#    define JSON_SCHEMA_VALIDATOR_API
+#endif
+
 #include <json.hpp>
 
 // make yourself a home - welcome to nlohmann's namespace
@@ -83,7 +93,7 @@ public:
 //
 // This is done implement the requirements described in section 8.2.
 //
-class json_uri
+class JSON_SCHEMA_VALIDATOR_API json_uri
 {
 	std::string urn_;
 
@@ -155,7 +165,7 @@ namespace json_schema_draft4
 
 extern json draft4_schema_builtin;
 
-class json_validator
+class JSON_SCHEMA_VALIDATOR_API json_validator
 {
 	std::vector<std::shared_ptr<json>> schema_store_;
 	std::shared_ptr<json> root_schema_;

--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -344,7 +344,7 @@ void json_validator::validate(const json &instance, const json &schema_, const s
 		try {
 			validate(instance, attr.value(), name);
 			ok = false;
-		} catch (std::exception &e) {
+        } catch (std::exception &) {
 			ok = true;
 		}
 		if (!ok)

--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -344,7 +344,7 @@ void json_validator::validate(const json &instance, const json &schema_, const s
 		try {
 			validate(instance, attr.value(), name);
 			ok = false;
-        } catch (std::exception &) {
+		} catch (std::exception &) {
 			ok = true;
 		}
 		if (!ok)


### PR DESCRIPTION
I have added preprocessor code to allow exporting the symbols from DLLs, conditionally disabled -Wextra and -Wall in case of Visual Studio compiler, and fixed two warnings.  After those changes, the only MSVC warning remaining is C4251 (https://msdn.microsoft.com/en-us/library/esew7y1w.aspx).  The subject of this issue is probably not a problem when building json-schema-validator and the code that uses it with the very same compiler.  Otherwise, it is flagging a potential problem, so this warning should probably not be suppressed.  