### PR TITLE
Added the option to disable dynamic library and build static instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,17 @@ if(NOT TARGET json-hpp)
 endif()
 
 # and one for the validator
-add_library(json-schema-validator SHARED
-    src/json-schema-draft4.json.cpp
-    src/json-uri.cpp
-    src/json-validator.cpp)
+if (JSON_SCHEMA_VALIDATOR_DISABLE_SHARED)
+    add_library(json-schema-validator STATIC
+        src/json-schema-draft4.json.cpp
+        src/json-uri.cpp
+        src/json-validator.cpp)
+else()
+    add_library(json-schema-validator SHARED
+            src/json-schema-draft4.json.cpp
+            src/json-uri.cpp
+            src/json-validator.cpp)
+endif()
 
 target_include_directories(json-schema-validator
     PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ else()
             src/json-schema-draft4.json.cpp
             src/json-uri.cpp
             src/json-validator.cpp)
+    target_compile_definitions(json-schema-validator
+            PRIVATE
+            -DJSON_SCHEMA_VALIDATOR_SHARED_LIB)
 endif()
 
 target_include_directories(json-schema-validator

--- a/src/json-schema.hpp
+++ b/src/json-schema.hpp
@@ -26,7 +26,7 @@
 #ifndef NLOHMANN_JSON_SCHEMA_HPP__
 #define NLOHMANN_JSON_SCHEMA_HPP__
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(JSON_SCHEMA_VALIDATOR_SHARED_LIB)
 #    ifdef JSON_SCHEMA_VALIDATOR_EXPORTS
 #        define JSON_SCHEMA_VALIDATOR_API __declspec(dllexport)
 #    else


### PR DESCRIPTION
It's useful for some platform (e.g. iOS) to build the validator as a static lib instead of dynamic.