### PR TITLE
Use more explicit path to nlohmann/json.hpp

### DIFF
--- a/src/json-schema.hpp
+++ b/src/json-schema.hpp
@@ -36,7 +36,7 @@
 #    define JSON_SCHEMA_VALIDATOR_API
 #endif
 
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 
 // make yourself a home - welcome to nlohmann's namespace
 namespace nlohmann


### PR DESCRIPTION
The path "json.hpp" is a bit dangerous because that path could be found in many libraries in theory and include directory determination could get confused by finding the wrong one.