### PR TITLE
Updated CMakeLists.txt to add install target when needed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 3.2)
 # and associate the path to json.hpp via target_include_directories()
 if(NOT TARGET json-hpp)
     set(NLOHMANN_JSON_DIR "" CACHE STRING "path to json.hpp")
+    set(ADD_INSTALL_TARGET TRUE)
 
     # find nlohmann's json.hpp
     find_path(JSON_HPP nlohmann/json.hpp
@@ -71,7 +72,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
-if(NOT TARGET json-hpp) # if used as a subdirectory do not install json-schema.hpp
+if(ADD_INSTALL_TARGET) # if used as a subdirectory do not install json-schema.hpp
     install(
         FILES
            ${CMAKE_CURRENT_SOURCE_DIR}/src/json-schema.hpp


### PR DESCRIPTION
As it stands, the install target for the header will never be created because it's predicated on the existence of the `json-hpp` target. But if the target does not exist initially it's created before hitting that conditional, so it's always false.

This change sets a flag if the install target wasn't initially defined upon executing the script, and if not, it will create the install target. So now you can install as you'd expect:

```
cmake -D NLOHMANN_JSON_DIR=<...> -D CMAKE_INSTALL_PREFIX=<...> ..
make install
```