### PR TITLE
resolve "$ref" with relative uri correctly. fixes #9

### DIFF
--- a/src/json-uri.cpp
+++ b/src/json-uri.cpp
@@ -86,8 +86,10 @@ void json_uri::from_string(const std::string &uri)
 		auto path = url.substr(pos);
 		if (path[0] == '/') // if it starts with a / it is root-path
 			path_ = path;
-		else // otherwise it is a subfolder
+		else { // otherwise it is a relative-path
+			path_ = path_.substr(0, path_.find_last_of('/') + 1);
 			path_.append(path);
+		}
 
 		pointer_ = local_json_pointer("");
 	}

--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -305,10 +305,10 @@ void json_validator::insert_schema(const json &input, const json_uri &id)
 	// allocate create a copy for later storage - if resolving reference works
 	std::shared_ptr<json> schema = std::make_shared<json>(input);
 
-	do {
-		// resolve all local schemas and references
-		resolver r(*schema, id);
+	// resolve all local schemas and local and external references
+	resolver r(*schema, id);
 
+	do {
 		// check whether all undefined schema references can be resolved with existing ones
 		std::set<json_uri> undefined;
 		for (auto &ref : r.undefined_refs)


### PR DESCRIPTION
As noted in #9, resolving of relative references is broken.

Some examples resolved by this PR:

Given a current id of "foo.json", a relative reference "bar.json" should resolve to "bar.json".
Given a current id of "foo/bar.json", a relative reference "baz.json" should resolve to "foo/baz.json".
Given a current id of "foo/bar.json", a relative reference "baz/qux.json" should resolve to "foo/baz/qux.json".

(Relative URIs with paths containing dot-segments (".." or ".") will work if the schema loader handles them, but they won't be removed in the schema refs, so these schemas may still be loaded more than once.)

This is achieved by fixing the ``json_uri::from_string`` handling of relative paths, and making sure the ``resolver`` is only applied to the schema object once (because it modifies the "$ref" values in-place).
