### PR TITLE
first experiment with upgrading from v1.0.0

### DIFF
--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -591,8 +591,8 @@ class numeric : public schema
 
 	std::pair<bool, json::number_float_t> multipleOf_{false, 0};
 
-	// multipleOf - if the rest of the division is 0 -> OK
-	bool violates_multiple_of(json::number_float_t x) const
+	// multipleOf - if the remainder of the division is 0 -> OK
+	bool violates_multiple_of(T x) const
 	{
 		json::number_integer_t n = static_cast<json::number_integer_t>(x / multipleOf_.second);
 		double res = (x - n * multipleOf_.second);

--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -340,8 +340,8 @@ class type_schema : public schema
 
 		if (enum_.first) {
 			bool seen_in_enum = false;
-			for (auto &e : enum_.second)
-				if (instance == e) {
+			for (auto &v : enum_.second)
+				if (instance == v) {
 					seen_in_enum = true;
 					break;
 				}

--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -594,9 +594,9 @@ class numeric : public schema
 	// multipleOf - if the remainder of the division is 0 -> OK
 	bool violates_multiple_of(T x) const
 	{
-		json::number_integer_t n = static_cast<json::number_integer_t>(x / multipleOf_.second);
-		double res = (x - n * multipleOf_.second);
-		return fabs(res) > std::numeric_limits<json::number_float_t>::epsilon();
+		double res = std::remainder(x, multipleOf_.second);
+		double eps = std::nextafter(x, 0) - x;
+		return std::fabs(res) > std::fabs(eps);
 	}
 
 	void validate(const json &instance, basic_error_handler &e) const override


### PR DESCRIPTION
Pleased to see the rewrite, as we've found things like repeated [recompiling of regex patterns in v1.0.0](https://github.com/pboettch/json-schema-validator/blob/1.0.0/src/json-validator.cpp#L694-L700), etc. to be a potential performance problem.

I've only just started playing with the rewrite, but I thought I'd immediately track things I found while trying to upgrade.

Four commits so far:

1. One missing #include
2. Backwards incompatibility - json_validator used to be copyable, it now wasn't even movable, so this commit fixes that
3. Delete whitespace either side of the '#' which indicates fragment identifier between the URI and json-pointer or local name (i.e. from a $id)
4. Update test for 3.

I'm seeing an exception from within test/id-ref.cpp:

```
  [json.exception.parse_error.107] parse error at byte 1: JSON pointer must be
  empty or begin with '/' - was: 'foo'
```

I haven't yet investigatd further, but does that mean $ref using a local name isn't working currently?

For reference, spec quote:

> All fragment identifiers that do
> not match the JSON Pointer syntax MUST be interpreted as
> plain name fragment identifiers.
