### PR TITLE
Added support to export cmake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,6 @@ if (BUILD_TESTS)
     add_subdirectory(test)
 endif()
 
-install ( EXPORT json-schema-validator
-          NAMESPACE json-schema-validator::
-          DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" )
+install(EXPORT json-schema-validator
+        NAMESPACE json-schema-validator::
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set_target_properties(json-schema-validator
                           SOVERSION 1)
 
 install(TARGETS json-schema-validator
+        EXPORT json-schema-validator
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin)
@@ -55,7 +56,8 @@ install(DIRECTORY src/
 
 target_include_directories(json-schema-validator
     PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<INSTALL_INTERFACE:include>)
 
 target_compile_features(json-schema-validator
     PUBLIC
@@ -117,3 +119,7 @@ if (BUILD_TESTS)
     enable_testing()
     add_subdirectory(test)
 endif()
+
+install ( EXPORT json-schema-validator
+          NAMESPACE json-schema-validator::
+          DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" )


### PR DESCRIPTION
I use the export functionality of cmake in my projects. If I use the json-schema-validator in my projects, cmake prints the following error.

`CMake Error: install(EXPORT "my-project" ...) includes target "my-project-static" which requires target "json-schema-validator" that is not in the export set.`

To fix this, the json-schema-validator must export it's targets too. The pull request fixes the error I have with my projects, but I think there must be added something more to fully support the cmake exports.