### PR TITLE
[DRAFT] Provide richer error info for logical combination schemas

### DIFF
--- a/src/json-schema.hpp
+++ b/src/json-schema.hpp
@@ -119,12 +119,22 @@ extern json draft7_schema_builtin;
 typedef std::function<void(const json_uri & /*id*/, json & /*value*/)> schema_loader;
 typedef std::function<void(const std::string & /*format*/, const std::string & /*value*/)> format_checker;
 
+// Validation error information
+struct JSON_SCHEMA_VALIDATOR_API error_info
+{
+	json::json_pointer ptr;
+	std::string message;
+	std::vector<error_info> subschema_errors;
+	// formatted error information including ptr, message and subschema errors
+	std::string formatted() const;
+};
+
 // Interface for validation error handlers
 class JSON_SCHEMA_VALIDATOR_API error_handler
 {
 public:
 	virtual ~error_handler() {}
-	virtual void error(const json::json_pointer & /*ptr*/, const json & /*instance*/, const std::string & /*message*/) = 0;
+	virtual void error(const error_info & /*err*/) = 0;
 };
 
 class JSON_SCHEMA_VALIDATOR_API basic_error_handler : public error_handler
@@ -132,7 +142,7 @@ class JSON_SCHEMA_VALIDATOR_API basic_error_handler : public error_handler
 	bool error_{false};
 
 public:
-	void error(const json::json_pointer & /*ptr*/, const json & /*instance*/, const std::string & /*message*/) override
+	void error(const error_info & /*err*/) override
 	{
 		error_ = true;
 	}


### PR DESCRIPTION
Follow-up to #52.

If a schema includes an "allOf", "anyOf" or "oneOf" near to the root, error messages are almost useless unless they go beyond "one of the subschemas is required to validate" and identify what the failures in each of the subschemas were. Gathering this error info would allow heuristics to be applied to identify the 'best match' (see https://github.com/json-schema-org/json-schema-spec/issues/632), or most nearly matching subschema.

This is a DRAFT pull request to gain feedback as to whether such an approach would fit into this library.
