### PR TITLE
Added Config file and updated install scripts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,12 @@ if(NOT TARGET json-hpp)
     add_library(json-hpp INTERFACE)
     target_include_directories(json-hpp
         INTERFACE
-            ${NLOHMANN_JSON_REALPATH})
+            $<INSTALL_INTERFACE:include>
+            $<BUILD_INTERFACE:${NLOHMANN_JSON_REALPATH}>)
+
+    install(TARGETS json-hpp EXPORT ${PROJECT_NAME}Targets)
+    install(FILES ${NLOHMANN_JSON_REALPATH}/nlohmann/json.hpp DESTINATION include/nlohmann)
+
 endif()
 
 # and one for the validator
@@ -45,6 +50,7 @@ set_target_properties(json-schema-validator
                           SOVERSION 1)
 
 install(TARGETS json-schema-validator
+        EXPORT ${PROJECT_NAME}Targets
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib
         RUNTIME DESTINATION bin)
@@ -55,7 +61,8 @@ install(DIRECTORY src/
 
 target_include_directories(json-schema-validator
     PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
 
 target_compile_features(json-schema-validator
     PUBLIC
@@ -117,3 +124,36 @@ if (BUILD_TESTS)
     enable_testing()
     add_subdirectory(test)
 endif()
+
+##---------------------------------------------------------------------------##
+## Set Up the Project Targets and Config Files for CMake
+##---------------------------------------------------------------------------##
+
+# Set the install path to the cmake config files
+set(INSTALL_CMAKE_DIR ${CMAKE_INSTALL_PREFIX}/lib/cmake/${PROJECT_NAME})
+
+# Create the ConfigVersion file
+include(CMakePackageConfigHelpers) # write_basic_package_version_file
+write_basic_package_version_file( ${PROJECT_NAME}ConfigVersion.cmake
+                                  VERSION ${PACKAGE_VERSION}
+                                  COMPATIBILITY SameMajorVersion)
+
+# Get the relative path from the INSTALL_CMAKE_DIR to the include directory
+file(RELATIVE_PATH REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}" "${CMAKE_INSTALL_PREFIX}/include")
+
+
+# Configure the Config.cmake file with the proper include directory
+set(CONF_INCLUDE_DIRS "\${JSON_SCHEMA_VALIDATOR_CMAKE_DIR}/${REL_INCLUDE_DIR}")
+configure_file(${PROJECT_NAME}Config.cmake.in
+               "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" @ONLY)
+
+# Install the Config.cmake and ConfigVersion.cmake files
+install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+        DESTINATION "${INSTALL_CMAKE_DIR}")
+
+# Install Targets
+install(EXPORT ${PROJECT_NAME}Targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        DESTINATION "${INSTALL_CMAKE_DIR}")

--- a/json-schema-validatorConfig.cmake.in
+++ b/json-schema-validatorConfig.cmake.in
@@ -1,0 +1,13 @@
+# Config file for the json-schema-validator
+# It defines the following variables
+#  JSON_SCHEMA_VALIDATOR_INCLUDE_DIRS - include directories for json-schema-validator
+#  json-schema-validator              - json-schema-validator library to link against
+
+# Compute paths
+get_filename_component(JSON_SCHEMA_VALIDATOR_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(JSON_SCHEMA_VALIDATOR_INCLUDE_DIRS @CONF_INCLUDE_DIRS@)
+
+# Our library dependencies (contains definitions for IMPORTED targets)
+if(NOT TARGET json-schema-validator)
+  include("${JSON_SCHEMA_VALIDATOR_CMAKE_DIR}/json-schema-validatorTargets.cmake")
+endif()

--- a/test/test_cmake_install/CMakeLists.txt
+++ b/test/test_cmake_install/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(PIPE_IN_TEST_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/../test-pipe-in.sh)
+
+# Configure install script
+configure_file(test_cmake_install.sh.in
+               ${CMAKE_CURRENT_BINARY_DIR}/test_cmake_install.sh @ONLY)
+
+# built-in tests
+add_test(NAME test_cmake_install
+         COMMAND ${PIPE_IN_TEST_SCRIPT}
+                 bash ${CMAKE_CURRENT_BINARY_DIR}/test_cmake_install.sh
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/test_cmake_install/test_cmake_install.sh.in
+++ b/test/test_cmake_install/test_cmake_install.sh.in
@@ -1,0 +1,52 @@
+#!/bin/bash
+##----------------------------------------------------##
+## Configure, build, isntall, and test json-schema-validator with CMAKE
+##----------------------------------------------------##
+
+EXTRA_ARGS=$@
+SRC_DIR=@PROJECT_SOURCE_DIR@
+BUILD_DIR=@CMAKE_CURRENT_BINARY_DIR@/build-dir
+INSTALL_DIR=@CMAKE_CURRENT_BINARY_DIR@/install-dir
+NLOHMANN_JSON_DIR=@NLOHMANN_JSON_DIR@
+TEST_SRC_DIR=@CMAKE_CURRENT_SOURCE_DIR@/test_project
+
+source ~/.bashrc
+
+cmake --version
+
+# Make sure build directory is empty
+mkdir -p ${BUILD_DIR}
+cd ${BUILD_DIR}
+# Clear out build directory
+rm -rf ./*
+
+# configure json-schema-validator
+printf "\n-----------------------------------------------------------\n"
+printf "Configuring, building, and installing json-schema-validator"
+printf "\n-----------------------------------------------------------\n"
+cmake \
+    -D CMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR} \
+    -D NLOHMANN_JSON_DIR:PATH=${NLOHMANN_JSON_DIR} \
+    ${EXTRA_ARGS} \
+    ${SRC_DIR}
+
+# Build and install json-schema-validator
+cmake --build . -- -j8
+cmake --build . --target install -- -j8
+
+# Make sure build directory is empty
+rm -rf ./*
+
+# configure test project
+printf "\n-----------------------------------------------------------\n"
+printf "Configuring, building, and running test project"
+printf "\n-----------------------------------------------------------\n"
+cmake \
+    -D CMAKE_INSTALL_PREFIX:PATH=test-project-install \
+    -D VALIDATOR_INSTALL_DIR:PATH=${INSTALL_DIR} \
+    ${EXTRA_ARGS} \
+    ${TEST_SRC_DIR}
+
+# Build test project and test
+cmake --build .
+ctest --output-on-failure

--- a/test/test_cmake_install/test_project/CMakeLists.txt
+++ b/test/test_cmake_install/test_project/CMakeLists.txt
@@ -1,0 +1,39 @@
+# This is a simple project that tests using cmake to load the installed libraries
+cmake_minimum_required(VERSION 3.2)
+
+project(cmake_install_test LANGUAGES CXX)
+
+set(PROJECT_VERSION 1.0.0)
+enable_testing()
+
+# Set the nlohmann json include directory used by json-schema-validator
+set(NLOHMANN_JSON_DIR "" CACHE STRING "path to json.hpp")
+
+# Set the json-schema-validator install directory
+set(VALIDATOR_INSTALL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../install-dir"
+    CACHE STRING "The json-schema-validator install directory")
+
+# Find the json-schema-validator package
+set(CMAKE_FIND_DEBUG_MODE ON)
+find_package(json-schema-validator REQUIRED HINTS ${VALIDATOR_INSTALL_DIR})
+
+# Add simple json-schema-validator-executable
+add_executable(json-schema-validate ${CMAKE_CURRENT_SOURCE_DIR}/../../../app/json-schema-validate.cpp)
+target_link_libraries(json-schema-validate json-schema-validator)
+
+# Add built-in tests function needed for issues
+set(PIPE_IN_TEST_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/../../test-pipe-in.sh)
+function(add_test_simple_schema name schema instance)
+    add_test(
+        NAME ${name}
+        COMMAND ${PIPE_IN_TEST_SCRIPT}
+            $<TARGET_FILE:json-schema-validate>
+            ${schema}
+            ${instance}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endfunction()
+
+# Run tests for issues 9, 12, 27, 48, 54
+foreach(NUMBER "9" "12" "27" "48" "54")
+  add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../issue-${NUMBER}" "${CMAKE_CURRENT_BINARY_DIR}/issue-${NUMBER}" EXCLUDE_FROM_ALL)
+endforeach()


### PR DESCRIPTION
Now when json-schema-validator is installed CMake config files are installed in the lib/cmake/json-schema-validator directory.
The install json-schema-validatorTargets.cmake file properly imports the json-hpp and json-schema-validator libraries.
The install json-schema-validatorConfig.cmake file is used by CMake find_package function to include the json-schema-validatorTargets.cmake file and to set the variable JSON_SCHEMA_VALIDATOR_INCLUDE_DIRS to the install include directory.
To use find_package to find the json-schema-validator simply include