### PR TITLE
Avoid copy of json on set_root_schema

### DIFF
--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -1150,6 +1150,11 @@ void json_validator::set_root_schema(const json &schema)
 	root_->set_root_schema(schema);
 }
 
+void json_validator::set_root_schema(json &&schema)
+{
+	root_->set_root_schema(std::move(schema));
+}
+
 void json_validator::validate(const json &instance) const
 {
 	throwing_error_handler err;

--- a/src/nlohmann/json-schema.hpp
+++ b/src/nlohmann/json-schema.hpp
@@ -176,6 +176,7 @@ public:
 
 	// insert and set the root-schema
 	void set_root_schema(const json &);
+	void set_root_schema(json &&);
 
 	// validate a json-document based on the root-schema
 	void validate(const json &) const;


### PR DESCRIPTION
If a json object containing a schema is moved into the json validator it
should not be copied. At least the public interface of the validator
class schould not force the copy.