### PR TITLE
using maybe_unused attribute only when supported

### DIFF
--- a/src/json-patch.cpp
+++ b/src/json-patch.cpp
@@ -1,5 +1,15 @@
 #include "json-patch.hpp"
 
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(maybe_unused)
+#define JSV_MAYBE_UNUSED [[maybe_unused]]
+#endif
+#endif
+
+#ifndef JSV_MAYBE_UNUSED
+#define JSV_MAYBE_UNUSED
+#endif
+
 namespace nlohmann
 {
 
@@ -59,7 +69,7 @@ void json_patch::validateJsonPatch(json const &patch)
 
 		try {
 			// try parse to path
-			[[maybe_unused]] const auto p = json::json_pointer{op["path"].get<std::string>()};
+			JSV_MAYBE_UNUSED const auto p = json::json_pointer{op["path"].get<std::string>()};
 		} catch (json::exception &e) {
 			throw JsonPatchFormatException{e.what()};
 		}

--- a/src/json-patch.cpp
+++ b/src/json-patch.cpp
@@ -1,15 +1,5 @@
 #include "json-patch.hpp"
 
-#ifdef __has_cpp_attribute
-#if __has_cpp_attribute(maybe_unused)
-#define JSV_MAYBE_UNUSED [[maybe_unused]]
-#endif
-#endif
-
-#ifndef JSV_MAYBE_UNUSED
-#define JSV_MAYBE_UNUSED
-#endif
-
 namespace nlohmann
 {
 
@@ -69,7 +59,7 @@ void json_patch::validateJsonPatch(json const &patch)
 
 		try {
 			// try parse to path
-			JSV_MAYBE_UNUSED const auto p = json::json_pointer{op["path"].get<std::string>()};
+			json::json_pointer{op["path"].get<std::string>()};
 		} catch (json::exception &e) {
 			throw JsonPatchFormatException{e.what()};
 		}


### PR DESCRIPTION
Making sure the current configuration supports [[maybe_unused]] before trying to compile with it

fixes #106 

I am not sure if there are any other usages of attributes this is the one that prevent me from  compiling

[build passing](https://travis-ci.com/github/prince-chrismc/json-schema-validator/builds/160911408)