### PR TITLE
Add functions to get library version at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,17 @@
-project(nlohmann_json_schema_validator
-        LANGUAGES CXX)
-
-set(PROJECT_VERSION 2.1.1)
 
 cmake_minimum_required(VERSION 3.2)
+cmake_policy(SET CMP0048 NEW) # Needed to set version with project
+
+project(nlohmann_json_schema_validator
+        VERSION 2.1.1
+        LANGUAGES CXX)
 
 option(BUILD_TESTS    "Build tests"    ON)
 option(BUILD_EXAMPLES "Build examples" ON)
+
+# generate file with version
+configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/src/nlohmann/json-schema.hpp.in"
+                "${CMAKE_CURRENT_SOURCE_DIR}/src/nlohmann/json-schema.hpp")
 
 # the library
 add_library(nlohmann_json_schema_validator

--- a/src/nlohmann/json-schema.hpp.in
+++ b/src/nlohmann/json-schema.hpp.in
@@ -131,19 +131,19 @@ namespace json_schema
 
 inline std::string get_schema_validator_version_string()
 {
-	return "2.1.1";
+	return "${PROJECT_VERSION}";
 }
 inline uint get_schema_validator_version_major()
 {
-	return 2;
+	return ${PROJECT_VERSION_MAJOR};
 }
 inline int get_schema_validator_version_minor()
 {
-	return 1;
+	return ${PROJECT_VERSION_MINOR};
 }
 inline uint get_schema_validator_version_patch()
 {
-	return 1;
+	return ${PROJECT_VERSION_PATCH};
 }
 
 extern json draft7_schema_builtin;


### PR DESCRIPTION
This add functions to get current library version.
Allow to retrieve MAJOR, MINOR, PATCH and a concatenated version string