### PR TITLE
Disable tests and examples when used via add_subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ if(TARGET nlohmann_json::nlohmann_json)
         PUBLIC nlohmann_json::nlohmann_json)
 
     set(JSON_VALIDATOR_INSTALL OFF)
+    set(BUILD_TESTS OFF)
+    set(BUILD_EXAMPLES OFF)
 
 elseif(TARGET nlohmann_json) # or nlohmann_json, we are used a sub-project next to nlohmann-json's git repo
     message(STATUS "Found nlohmann_json-target - linking with it")
@@ -52,6 +54,8 @@ elseif(TARGET nlohmann_json) # or nlohmann_json, we are used a sub-project next 
         nlohmann_json_schema_validator
         PUBLIC nlohmann_json)
     set(JSON_VALIDATOR_INSTALL OFF)
+    set(BUILD_TESTS OFF)
+    set(BUILD_EXAMPLES OFF)
 
 else()
     if (NOT IS_ABSOLUTE ${nlohmann_json_DIR}) # make nlohmann_json_DIR absolute


### PR DESCRIPTION
Similarly to how installation is disabled when included via ``add_subdirectory``, I believe test and example building should be disabled as well.

It seems that CMake does not make it possible to set options only for a sub-project without affecting the parent project. An alternative to this PR would be to rename ``BUILD_TESTS`` and ``BUILD_EXAMPLES`` to be globally unique so they can be set in the parent.