### PR TITLE
fix default is empty object

### DIFF
--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -33,7 +33,7 @@ using namespace nlohmann::json_schema;
 namespace
 {
 
-static const json EmptyDefault{};
+static const json EmptyDefault = nullptr;
 
 class schema
 {
@@ -402,7 +402,7 @@ bool logical_combination<oneOf>::is_validate_complete(const json &instance, cons
 
 class type_schema : public schema
 {
-	json defaultValue_{};
+	json defaultValue_ = EmptyDefault;
 	std::vector<std::shared_ptr<schema>> type_;
 	std::pair<bool, json> enum_, const_;
 	std::vector<std::shared_ptr<schema>> logic_;
@@ -882,7 +882,7 @@ class object : public schema
 			const auto finding = instance.find(prop.first);
 			if (instance.end() == finding) { // if the prop is not in the instance
 				const auto &defaultValue = prop.second->defaultValue(ptr, instance, e);
-				if (!defaultValue.empty()) { // if default value is available
+				if (!defaultValue.is_null()) { // if default value is available
 					patch.add((ptr / prop.first), defaultValue);
 				}
 			}

--- a/test/issue-25-default-values.cpp
+++ b/test/issue-25-default-values.cpp
@@ -28,6 +28,25 @@ static const json person_schema = R"(
                     "default": "Abbey Road"
                 }
             }
+        },
+        "work address": {
+            "type": "object",
+            "default": null,
+            "properties": {
+                "street": {
+                    "type": "string",
+                    "default": "Abbey Road"
+                }
+            }
+        },
+        "other address": {
+            "type": "object",
+            "properties": {
+                "street": {
+                    "type": "string",
+                    "default": "Abbey Road"
+                }
+            }
         }
     },
     "required": [
@@ -98,7 +117,8 @@ int main(void)
 		}
 	}
 	{
-		// add address which is optional that should generate a diff containing a default street
+		// add address which is optional that should generate a diff containing a empty object
+		// but not work address which is null or other address which has no default
 		json person_missing_address = R"({
 		"name": "Hans",
 		"age": 69


### PR DESCRIPTION
Hello,

This fix resolve a issue we faced with empty object as default value. Previous behavior of null as default value is the same (is_empty on a null json return true).

Here is a example of new behavior:

Schema:
```
{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "title": "A person",
    "properties": {
      "address":{
        "type": "object",
        "default": {}
      }
    },
    "type": "object"
}
```

Object:
`{}`

Patch:
```
[{"op":"add","path":"/address","value":{}}]
```

Object after applying patch:
```
{
  "address": {}
}
```