### PR TITLE
Fixed Hunter integration and added tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,3 +67,12 @@ script:
   - cmake .. -Dnlohmann_json_DIR=.. ${CMAKE_OPTIONS} -GNinja && cmake --build . --config Release
   - ctest -C Release -V -j
   - cd ..
+
+  # Remove previous build and tests
+  - rm -r build
+
+  # Compile and execute with Hunter package manager instead of using local json.hpp
+  - mkdir -p build && cd build
+  - cmake .. -DHUNTER_ENABLED=ON ${CMAKE_OPTIONS} -GNinja && cmake --build . --config Release
+  - ctest -C Release -V -j
+  - cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,13 @@
+# Add Hunter support (Disabled by default)
+option(HUNTER_ENABLED "Enable Hunter package manager support" OFF)
+if(HUNTER_ENABLED)
+    include("cmake/HunterGate.cmake")
+    HunterGate(
+        URL "https://github.com/cpp-pm/hunter/archive/v0.23.262.tar.gz"
+        SHA1 "eb51e633e08cdbe2153caf255e9c23968fecb29d"
+    )
+endif()
+
 project(nlohmann_json_schema_validator
         LANGUAGES CXX)
 
@@ -8,13 +18,8 @@ cmake_minimum_required(VERSION 3.2)
 option(BUILD_TESTS    "Build tests"    ON)
 option(BUILD_EXAMPLES "Build examples" ON)
 
-option(HUNTER_ENABLED "Enable Hunter package manager support" OFF)
+# Add nlohmann_json::nlohmann_json using Hunter package manager
 if(HUNTER_ENABLED)
-    include(cmake/HunterGate.cmake)
-    HunterGate(URL https://github.com/cpp-pm/hunter/archive/v0.23.253.tar.gz
-               SHA1 88ea6d37c897a81a080eb9ae0f69d7807bbb3c73)
-
-    # Add nlohmann_json::nlohmann_json (if HUNTER_ENABLED=ON, otherwise command is ignored)
     hunter_add_package(nlohmann_json)
 endif()
 


### PR DESCRIPTION
This is a follow up to PR #121. It fixes the integration, adds travis tests using Hunter package manager to retrieve nlohmann json library. 
It also includes the MSVC fix.
Branch was rebased to master and commits squashed. 