### PR TITLE
Remove unnecessary call to std::tie (fixes compilation error on MSVC 2017)

### DIFF
--- a/src/nlohmann/json-schema.hpp
+++ b/src/nlohmann/json-schema.hpp
@@ -59,7 +59,7 @@ protected:
 	// decodes a JSON uri and replaces all or part of the currently stored values
 	void update(const std::string &uri);
 
-	std::tuple<std::string, std::string, std::string, std::string, std::string> tie() const
+	std::tuple<std::string, std::string, std::string, std::string, std::string> as_tuple() const
 	{
 		return {urn_, scheme_, authority_, path_, identifier_ != "" ? identifier_ : pointer_};
 	}
@@ -114,12 +114,12 @@ public:
 
 	friend bool operator<(const json_uri &l, const json_uri &r)
 	{
-		return l.tie() < r.tie();
+		return l.as_tuple() < r.as_tuple();
 	}
 
 	friend bool operator==(const json_uri &l, const json_uri &r)
 	{
-		return l.tie() == r.tie();
+		return l.as_tuple() == r.as_tuple();
 	}
 
 	friend std::ostream &operator<<(std::ostream &os, const json_uri &u);

--- a/src/nlohmann/json-schema.hpp
+++ b/src/nlohmann/json-schema.hpp
@@ -61,8 +61,7 @@ protected:
 
 	std::tuple<std::string, std::string, std::string, std::string, std::string> tie() const
 	{
-		return std::tie(urn_, scheme_, authority_, path_,
-		                identifier_ != "" ? identifier_ : pointer_);
+		return {urn_, scheme_, authority_, path_, identifier_ != "" ? identifier_ : pointer_};
 	}
 
 public:


### PR DESCRIPTION
Thanks for the great library :)

The call to std::tie was causing a compiler error on MSVC 2017:

```
json-schema.hpp(64): error C2664: 'std::tuple<const std::string &,const std::string &,const std::string &,const std::string &,std::string &> std::tie<const std::string,const std::string,const std::string,const std::string,std::string>(const std::string &,const std::string &,const std::string &,const std::string &,std::string &) noexcept': cannot convert argument 5 from 'std::string' to 'std::string &'
json-schema.hpp(65): note: A non-const reference may only be bound to an lvalue
```

I was able to reduce the problem to the following code snippet that [compiles on gcc/clang](https://wandbox.org/permlink/Vg5b71MshLatmtVz), but fails to compile on MSVC 2017:

```
#include <string>
#include <tuple>

struct S {
	operator std::string() const {
		return std::string();
	}
};

std::tuple<std::string> f() {
	const S s;
	const std::string str;
	return std::tie(str != "" ? str : s);
}

int main() {}
```

I fixed the error by removing the call to `std::tie` and initializing the `std::tuple` directly instead. If I understand correctly, `std::tie` is not needed here anyway, as it creates a tuple of lvalue references, whereas we want to return an `std::tuple` that packs the values.

Note 1: Recent versions of MSVC 2019 seem not to complain about the issue. The result of deducing the type of the ternary operator expression in `std::tie` is `const std::string&`, while on my MSVC 2017 installation, the type is `std::string&` (which can't bind to the temporary `std::string` produced after implicitly converting `pointer_`). I tried searching for the exact issue on their bug tracker, but I had no luck.

Note 2: In my understanding, the name of the function `json_uri::tie()` does not really fit its return type; A user might think that they are able to modify the object members through the returned tuple, while in fact, the returned tuple stores a copy of these members. Wouldn't something like `as_tuple()` be more suitable here? I would like to hear your opinions.

Thank you very much for making this library available.