### PR TITLE
Fix explicit tuple constructor error on gcc-5

### DIFF
--- a/src/nlohmann/json-schema.hpp
+++ b/src/nlohmann/json-schema.hpp
@@ -61,7 +61,7 @@ protected:
 
 	std::tuple<std::string, std::string, std::string, std::string, std::string> as_tuple() const
 	{
-		return {urn_, scheme_, authority_, path_, identifier_ != "" ? identifier_ : pointer_};
+		return std::make_tuple(urn_, scheme_, authority_, path_, identifier_ != "" ? identifier_ : pointer_);
 	}
 
 public:


### PR DESCRIPTION
Apparently, [my fix for MSVC 2017](https://github.com/pboettch/json-schema-validator/pull/137) has broken compilation on pre-[N4387](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4387.html) `std::tuple` implementations. This is currently noticeable in the CI build status, where compilation fails on both gcc-4.9 and gcc-5. 

In this PR, I switched to using `std::make_tuple` instead of list initialization. This avoids relying on the presence of a viable non-explicit constructor in `std::tuple`, making the code valid for old C++11 `std::tuple` implementations as well.

Sorry, I just learned about this paper when I saw the "build failing" CI label in the project README.

Thanks again!
