### PR TITLE
Minor patch for bash 3.2 compatibility

### DIFF
--- a/test/test-pipe-in.sh
+++ b/test/test-pipe-in.sh
@@ -7,7 +7,7 @@ set -e
 
 arr=( "$@" )
 
-input=${arr[-1]}
+input=${arr[${#arr[@]}-1]}
 unset 'arr[${#arr[@]}-1]'
 
 ${arr[@]} < $input


### PR DESCRIPTION
Default bash on macOS is bash 3.2, which does not support negative array indexing causing unit tests to appear to fail (#144 , #141). This syntax (copied from https://unix.stackexchange.com/a/198788/178794) corrects the issue by avoiding the use of a negative index.