### PR TITLE
Remove conditional assignments to JSON_VALIDATOR_INSTALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ if(TARGET nlohmann_json::nlohmann_json)
         nlohmann_json_schema_validator
         PUBLIC nlohmann_json::nlohmann_json)
 
-    set(JSON_VALIDATOR_INSTALL OFF)
     set(BUILD_TESTS OFF)
     set(BUILD_EXAMPLES OFF)
 
@@ -68,7 +67,7 @@ elseif(TARGET nlohmann_json) # or nlohmann_json, we are used a sub-project next 
     target_link_libraries(
         nlohmann_json_schema_validator
         PUBLIC nlohmann_json)
-    set(JSON_VALIDATOR_INSTALL OFF)
+
     set(BUILD_TESTS OFF)
     set(BUILD_EXAMPLES OFF)
 


### PR DESCRIPTION
Hi Patrick,

These two conditional assignments that turn `OFF` the `JSON_VALIDATOR_INSTALL` option do not seem to be correct. The assignments are causing an error in what I think is a relatively common use-case, which I describe in the following:

We are working on a project that uses nlohmann::json as a submodule. We would also like to use your json-schema-validator project as a submodule to validate json files that our project is handling. Our project uses CMake and, of course, also allows its users to install certain components to their system. When CMake installs the component of our project (as a library) that uses json-related code, it also needs to install nlohmann::json, which works fine, and it needs to install your json-schema-validator library as we are linking dynamically. But CMake throws an error at us when the `JSON_VALIDATOR_INSTALL` variable is set to `OFF`, since it has to install the library but does not find the respective `install(EXPORT ...` stuff that is hidden behind said variable. 

Removing those conditional assignments fixes the error and allows us to use your schema validator.

Thanks for this very useful project.

Best,
Philipp