### PR TITLE
Updated exclusive min/max error message #182

### DIFF
--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -804,15 +804,19 @@ class numeric : public schema
 			if (violates_multiple_of(value))
 				e.error(ptr, instance, "instance is not a multiple of " + std::to_string(multipleOf_.second));
 
-		if (maximum_.first)
-			if ((exclusiveMaximum_ && value >= maximum_.second) ||
-			    value > maximum_.second)
+		if (maximum_.first) {
+			if (exclusiveMaximum_ && value >= maximum_.second)
+				e.error(ptr, instance, "instance exceeds or equals maximum of " + std::to_string(maximum_.second));
+			else if (value > maximum_.second)
 				e.error(ptr, instance, "instance exceeds maximum of " + std::to_string(maximum_.second));
+		}
 
-		if (minimum_.first)
-			if ((exclusiveMinimum_ && value <= minimum_.second) ||
-			    value < minimum_.second)
+		if (minimum_.first) {
+			if (exclusiveMinimum_ && value <= minimum_.second)
+				e.error(ptr, instance, "instance is below or equals minimum of " + std::to_string(minimum_.second));
+			else if (value < minimum_.second)
 				e.error(ptr, instance, "instance is below minimum of " + std::to_string(minimum_.second));
+		}
 	}
 
 public:


### PR DESCRIPTION
The error messages for exclusive minimum and maximum have been updated
to include 'or equals' for greater clarity.