### PR TITLE
Optional CMake Install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
-# Add Hunter support (Disabled by default)
-option(HUNTER_ENABLED "Enable Hunter package manager support" OFF)
-if(HUNTER_ENABLED)
+cmake_minimum_required(VERSION 3.2)
+
+option(JSON_VALIDATOR_BUILD_TESTS    "Build tests"    ON)
+option(JSON_VALIDATOR_BUILD_EXAMPLES "Build examples" ON)
+option(JSON_VALIDATOR_HUNTER "Enable Hunter package manager support" OFF)
+
+if(JSON_VALIDATOR_HUNTER)
     include("cmake/HunterGate.cmake")
     HunterGate(
         URL "https://github.com/cpp-pm/hunter/archive/v0.23.262.tar.gz"
@@ -8,18 +12,13 @@ if(HUNTER_ENABLED)
     )
 endif()
 
+# the project
 project(nlohmann_json_schema_validator
         LANGUAGES CXX)
 
 set(PROJECT_VERSION 2.1.1)
 
-cmake_minimum_required(VERSION 3.2)
-
-option(BUILD_TESTS    "Build tests"    ON)
-option(BUILD_EXAMPLES "Build examples" ON)
-
-# Add nlohmann_json::nlohmann_json using Hunter package manager
-if(HUNTER_ENABLED)
+if(JSON_VALIDATOR_HUNTER)
     hunter_add_package(nlohmann_json)
 endif()
 
@@ -52,11 +51,11 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
 endif()
 
 if(JSON_VALIDATOR_IS_TOP_LEVEL)
-    set(BUILD_TESTS ON)
-    set(BUILD_EXAMPLES ON)
+    set(JSON_VALIDATOR_BUILD_TESTS ON)
+    set(JSON_VALIDATOR_BUILD_EXAMPLES ON)
 else()
-    set(BUILD_TESTS OFF)
-    set(BUILD_EXAMPLES OFF)
+    set(JSON_VALIDATOR_BUILD_TESTS OFF)
+    set(JSON_VALIDATOR_BUILD_EXAMPLES OFF)
 endif()
 
 if(NOT TARGET nlohmann_json::nlohmann_json)
@@ -105,7 +104,7 @@ install(TARGETS nlohmann_json_schema_validator
 install(FILES src/nlohmann/json-schema.hpp
         DESTINATION include/nlohmann)
 
-if (BUILD_EXAMPLES)
+if (JSON_VALIDATOR_BUILD_EXAMPLES)
     # simple nlohmann_json_schema_validator-executable
     add_executable(json-schema-validate app/json-schema-validate.cpp)
     target_link_libraries(json-schema-validate nlohmann_json_schema_validator)
@@ -120,7 +119,7 @@ if (BUILD_EXAMPLES)
             DESTINATION bin)
 endif()
 
-if (BUILD_TESTS)
+if (JSON_VALIDATOR_BUILD_TESTS)
     # test-zone
     enable_testing()
     add_subdirectory(test)
@@ -137,14 +136,12 @@ install(EXPORT ${PROJECT_NAME}Targets
         FILE ${PROJECT_NAME}Targets.cmake
         DESTINATION "${INSTALL_CMAKE_DIR}")
 
-
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion
     )
-
 
 configure_package_config_file(
     ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}Config.cmake.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,15 @@
 cmake_minimum_required(VERSION 3.2)
 
-option(JSON_VALIDATOR_BUILD_TESTS    "Build tests"    ON)
-option(JSON_VALIDATOR_BUILD_EXAMPLES "Build examples" ON)
+# disable tests and examples if project is not super project
+set(JSON_VALIDATOR_IS_TOP_LEVEL OFF)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    # I am top-level project.
+    set(JSON_VALIDATOR_IS_TOP_LEVEL ON)
+endif()
+
+option(JSON_VALIDATOR_BUILD_TESTS    "Build tests"    ${JSON_VALIDATOR_IS_TOP_LEVEL})
+option(JSON_VALIDATOR_BUILD_EXAMPLES "Build examples" ${JSON_VALIDATOR_IS_TOP_LEVEL})
+option(JSON_VALIDATOR_INSTALL "Install CMake targets during install step." ${JSON_VALIDATOR_IS_TOP_LEVEL})
 option(JSON_VALIDATOR_HUNTER "Enable Hunter package manager support" OFF)
 
 if(JSON_VALIDATOR_HUNTER)
@@ -44,20 +52,6 @@ set_target_properties(nlohmann_json_schema_validator
                           VERSION ${PROJECT_VERSION}
                           SOVERSION 1)
 
-# disable tests and examples if project is not super project
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-    # I am top-level project.
-    set(JSON_VALIDATOR_IS_TOP_LEVEL TRUE)
-endif()
-
-if(JSON_VALIDATOR_IS_TOP_LEVEL)
-    set(JSON_VALIDATOR_BUILD_TESTS ON)
-    set(JSON_VALIDATOR_BUILD_EXAMPLES ON)
-else()
-    set(JSON_VALIDATOR_BUILD_TESTS OFF)
-    set(JSON_VALIDATOR_BUILD_EXAMPLES OFF)
-endif()
-
 if(NOT TARGET nlohmann_json::nlohmann_json)
     find_package(nlohmann_json REQUIRED)
 endif()
@@ -95,15 +89,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
-install(TARGETS nlohmann_json_schema_validator
-        EXPORT ${PROJECT_NAME}Targets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin)
-
-install(FILES src/nlohmann/json-schema.hpp
-        DESTINATION include/nlohmann)
-
 if (JSON_VALIDATOR_BUILD_EXAMPLES)
     # simple nlohmann_json_schema_validator-executable
     add_executable(json-schema-validate app/json-schema-validate.cpp)
@@ -114,9 +99,6 @@ if (JSON_VALIDATOR_BUILD_EXAMPLES)
 
     add_executable(format-json-schema app/format.cpp)
     target_link_libraries(format-json-schema nlohmann_json_schema_validator)
-
-    install(TARGETS json-schema-validate readme-json-schema
-            DESTINATION bin)
 endif()
 
 if (JSON_VALIDATOR_BUILD_TESTS)
@@ -125,34 +107,50 @@ if (JSON_VALIDATOR_BUILD_TESTS)
     add_subdirectory(test)
 endif()
 
-# Set Up the Project Targets and Config Files for CMake
+if(JSON_VALIDATOR_INSTALL)
+    install(TARGETS nlohmann_json_schema_validator
+            EXPORT ${PROJECT_NAME}Targets
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib
+            RUNTIME DESTINATION bin)
 
-# Set the install path to the cmake config files (Relative, so install works correctly under Hunter as well)
-set(INSTALL_CMAKE_DIR "lib/cmake/${PROJECT_NAME}")
-set(INSTALL_CMAKEDIR_ROOT share/cmake)
+    install(FILES src/nlohmann/json-schema.hpp
+            DESTINATION include/nlohmann)
 
-# Install Targets
-install(EXPORT ${PROJECT_NAME}Targets
-        FILE ${PROJECT_NAME}Targets.cmake
-        DESTINATION "${INSTALL_CMAKE_DIR}")
+    if (JSON_VALIDATOR_BUILD_EXAMPLES)
+        install(TARGETS json-schema-validate readme-json-schema
+                DESTINATION bin)
+    endif()
 
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
-    )
+    # Set Up the Project Targets and Config Files for CMake
 
-configure_package_config_file(
-    ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}Config.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-    INSTALL_DESTINATION ${INSTALL_CMAKEDIR_ROOT}/${PROJECT_NAME}
-    )
+    # Set the install path to the cmake config files (Relative, so install works correctly under Hunter as well)
+    set(INSTALL_CMAKE_DIR "lib/cmake/${PROJECT_NAME}")
+    set(INSTALL_CMAKEDIR_ROOT share/cmake)
 
-install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    # Install Targets
+    install(EXPORT ${PROJECT_NAME}Targets
+            FILE ${PROJECT_NAME}Targets.cmake
+            DESTINATION "${INSTALL_CMAKE_DIR}")
+
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-    DESTINATION
-        ${INSTALL_CMAKE_DIR}
-    )
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+        )
+
+    configure_package_config_file(
+        ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}Config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+        INSTALL_DESTINATION ${INSTALL_CMAKEDIR_ROOT}/${PROJECT_NAME}
+        )
+
+    install(
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        DESTINATION
+            ${INSTALL_CMAKE_DIR}
+        )
+endif()

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ Otherwise, it calls `find_package` for nlohmann-json and requires nlohmann-json 
 
 ### Building with Hunter package manager
 
-To enable access to nlohmann json library, Hunter can be used. Just run with HUNTER_ENABLED=ON option. No further dependencies needed
+To enable access to nlohmann json library, Hunter can be used. Just run with `JSON_VALIDATOR_HUNTER=ON` option. No further dependencies needed
 
 ```bash
-cmake [..] -DHUNTER_ENABLED=ON [..]
+cmake [..] -DJSON_VALIDATOR_HUNTER=ON [..]
 ```
 
 ### Building as a CMake-subdirectory from within another project

--- a/conanfile.py
+++ b/conanfile.py
@@ -45,8 +45,8 @@ class JsonSchemaValidatorConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions['nlohmann_json_DIR'] = os.path.join(self.deps_cpp_info['nlohmann_json'].rootpath, 'include')
-        cmake.definitions['BUILD_EXAMPLES'] = True
-        cmake.definitions['BUILD_TESTS'] = False
+        cmake.definitions['JSON_VALIDATOR_BUILD_EXAMPLES'] = True
+        cmake.definitions['JSON_VALIDATOR_BUILD_TESTS'] = False
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Fix for #181 - option to not install re-added, but can be overridden. The default is to not install if included as a submodule, preserving old behavior. This is a branch off of #179.

Other changes:
* Install/don't install is now a single branch at the end of CMakeLists.txt.
* Moved the options below detection of top level project - previously, the options were overridden by the later SET statements, so setting them from the command line or a higher-level CMakeLists.txt wouldn't work.

Caveats: 
* If nlohmann::json and json-schema-validator are included as submodules, and json-schema-validator is set to install but nlohmann::json is not, the build will still fail.
* I've only tested this in the context of submodules, with various options set or not set. I haven't tested it as a standalone install.