### PR TITLE
add back JSON_VALIDATOR_INSTALL and disable it if not top level project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.2)
 
 option(JSON_VALIDATOR_BUILD_TESTS    "Build tests"    ON)
 option(JSON_VALIDATOR_BUILD_EXAMPLES "Build examples" ON)
-option(JSON_VALIDATOR_HUNTER "Enable Hunter package manager support" OFF)
+option(JSON_VALIDATOR_INSTALL        "Install" ON)
+option(JSON_VALIDATOR_HUNTER         "Enable Hunter package manager" OFF)
 
 if(JSON_VALIDATOR_HUNTER)
     include("cmake/HunterGate.cmake")
@@ -50,12 +51,10 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     set(JSON_VALIDATOR_IS_TOP_LEVEL TRUE)
 endif()
 
-if(JSON_VALIDATOR_IS_TOP_LEVEL)
-    set(JSON_VALIDATOR_BUILD_TESTS ON)
-    set(JSON_VALIDATOR_BUILD_EXAMPLES ON)
-else()
+if(NOT JSON_VALIDATOR_IS_TOP_LEVEL)
     set(JSON_VALIDATOR_BUILD_TESTS OFF)
     set(JSON_VALIDATOR_BUILD_EXAMPLES OFF)
+    set(JSON_VALIDATOR_INSTALL OFF)
 endif()
 
 if(NOT TARGET nlohmann_json::nlohmann_json)
@@ -95,15 +94,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     endif()
 endif()
 
-install(TARGETS nlohmann_json_schema_validator
-        EXPORT ${PROJECT_NAME}Targets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin)
-
-install(FILES src/nlohmann/json-schema.hpp
-        DESTINATION include/nlohmann)
-
 if (JSON_VALIDATOR_BUILD_EXAMPLES)
     # simple nlohmann_json_schema_validator-executable
     add_executable(json-schema-validate app/json-schema-validate.cpp)
@@ -125,34 +115,45 @@ if (JSON_VALIDATOR_BUILD_TESTS)
     add_subdirectory(test)
 endif()
 
-# Set Up the Project Targets and Config Files for CMake
+if (JSON_VALIDATOR_INSTALL)
+    # add install target
+    install(TARGETS nlohmann_json_schema_validator
+            EXPORT ${PROJECT_NAME}Targets
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib
+            RUNTIME DESTINATION bin)
 
-# Set the install path to the cmake config files (Relative, so install works correctly under Hunter as well)
-set(INSTALL_CMAKE_DIR "lib/cmake/${PROJECT_NAME}")
-set(INSTALL_CMAKEDIR_ROOT share/cmake)
+    install(FILES src/nlohmann/json-schema.hpp
+            DESTINATION include/nlohmann)
 
-# Install Targets
-install(EXPORT ${PROJECT_NAME}Targets
-        FILE ${PROJECT_NAME}Targets.cmake
-        DESTINATION "${INSTALL_CMAKE_DIR}")
+    # Set Up the Project Targets and Config Files for CMake
+    # Set the install path to the cmake config files (Relative, so install works correctly under Hunter as well)
+    set(INSTALL_CMAKE_DIR "lib/cmake/${PROJECT_NAME}")
+    set(INSTALL_CMAKEDIR_ROOT share/cmake)
 
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
-    )
+    # Install Targets
+    install(EXPORT ${PROJECT_NAME}Targets
+            FILE ${PROJECT_NAME}Targets.cmake
+            DESTINATION "${INSTALL_CMAKE_DIR}")
 
-configure_package_config_file(
-    ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}Config.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-    INSTALL_DESTINATION ${INSTALL_CMAKEDIR_ROOT}/${PROJECT_NAME}
-    )
-
-install(
-    FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-    DESTINATION
-        ${INSTALL_CMAKE_DIR}
-    )
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+        )
+
+    configure_package_config_file(
+        ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}Config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+        INSTALL_DESTINATION ${INSTALL_CMAKEDIR_ROOT}/${PROJECT_NAME}
+        )
+
+    install(
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        DESTINATION
+            ${INSTALL_CMAKE_DIR}
+        )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,16 @@
 cmake_minimum_required(VERSION 3.2)
 
-option(JSON_VALIDATOR_BUILD_TESTS    "Build tests"    ON)
-option(JSON_VALIDATOR_BUILD_EXAMPLES "Build examples" ON)
-option(JSON_VALIDATOR_INSTALL        "Install" ON)
-option(JSON_VALIDATOR_HUNTER         "Enable Hunter package manager" OFF)
+# disable tests and examples if project is not super project
+set(JSON_VALIDATOR_IS_TOP_LEVEL OFF)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    # I am top-level project.
+    set(JSON_VALIDATOR_IS_TOP_LEVEL ON)
+endif()
+
+option(JSON_VALIDATOR_BUILD_TESTS    "Build tests"    ${JSON_VALIDATOR_IS_TOP_LEVEL})
+option(JSON_VALIDATOR_BUILD_EXAMPLES "Build examples" ${JSON_VALIDATOR_IS_TOP_LEVEL})
+option(JSON_VALIDATOR_INSTALL "Install CMake targets during install step." ${JSON_VALIDATOR_IS_TOP_LEVEL})
+option(JSON_VALIDATOR_HUNTER "Enable Hunter package manager support" OFF)
 
 if(JSON_VALIDATOR_HUNTER)
     include("cmake/HunterGate.cmake")
@@ -44,18 +51,6 @@ set_target_properties(nlohmann_json_schema_validator
                       PROPERTIES
                           VERSION ${PROJECT_VERSION}
                           SOVERSION 1)
-
-# disable tests and examples if project is not super project
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-    # I am top-level project.
-    set(JSON_VALIDATOR_IS_TOP_LEVEL TRUE)
-endif()
-
-if(NOT JSON_VALIDATOR_IS_TOP_LEVEL)
-    set(JSON_VALIDATOR_BUILD_TESTS OFF)
-    set(JSON_VALIDATOR_BUILD_EXAMPLES OFF)
-    set(JSON_VALIDATOR_INSTALL OFF)
-endif()
 
 if(NOT TARGET nlohmann_json::nlohmann_json)
     find_package(nlohmann_json REQUIRED)
@@ -104,9 +99,6 @@ if (JSON_VALIDATOR_BUILD_EXAMPLES)
 
     add_executable(format-json-schema app/format.cpp)
     target_link_libraries(format-json-schema nlohmann_json_schema_validator)
-
-    install(TARGETS json-schema-validate readme-json-schema
-            DESTINATION bin)
 endif()
 
 if (JSON_VALIDATOR_BUILD_TESTS)
@@ -115,8 +107,7 @@ if (JSON_VALIDATOR_BUILD_TESTS)
     add_subdirectory(test)
 endif()
 
-if (JSON_VALIDATOR_INSTALL)
-    # add install target
+if(JSON_VALIDATOR_INSTALL)
     install(TARGETS nlohmann_json_schema_validator
             EXPORT ${PROJECT_NAME}Targets
             LIBRARY DESTINATION lib
@@ -126,7 +117,13 @@ if (JSON_VALIDATOR_INSTALL)
     install(FILES src/nlohmann/json-schema.hpp
             DESTINATION include/nlohmann)
 
+    if (JSON_VALIDATOR_BUILD_EXAMPLES)
+        install(TARGETS json-schema-validate readme-json-schema format-json-schema
+                DESTINATION bin)
+    endif()
+
     # Set Up the Project Targets and Config Files for CMake
+
     # Set the install path to the cmake config files (Relative, so install works correctly under Hunter as well)
     set(INSTALL_CMAKE_DIR "lib/cmake/${PROJECT_NAME}")
     set(INSTALL_CMAKEDIR_ROOT share/cmake)


### PR DESCRIPTION
* [x] re add `JSON_VALIDATOR_INSTALL` but now `JSON_VALIDATOR_IS_TOP_LEVEL` disable it
* [x] tested as a submodule or using `Fetch_content`
* [x] tested as main project using hunter to get  `nlohmann_json`
* [x] fix #181  

```bash
mkdir build
cd build
cmake -DCMAKE_INSTALL_PREFIX=install ..
make install
```

returns :

```bash
Install the project...
-- Install configuration: ""
-- Installing: ./install/bin/json-schema-validate
-- Installing: ./install/bin/readme-json-schema
-- Installing: ./install/lib/libnlohmann_json_schema_validator.a
-- Installing: ./install/include/nlohmann/json-schema.hpp
-- Installing: ./install/lib/cmake/nlohmann_json_schema_validator/nlohmann_json_schema_validatorTargets.cmake
-- Installing: ./install/lib/cmake/nlohmann_json_schema_validator/nlohmann_json_schema_validatorTargets-noconfig.cmake
-- Installing: ./install/lib/cmake/nlohmann_json_schema_validator/nlohmann_json_schema_validatorConfig.cmake
-- Installing: ./install/lib/cmake/nlohmann_json_schema_validator/nlohmann_json_schema_validatorConfigVersion.cmake
```
