### PR TITLE
Add dll export macro to format check

### DIFF
--- a/src/nlohmann/json-schema.hpp
+++ b/src/nlohmann/json-schema.hpp
@@ -159,7 +159,7 @@ public:
 /**
  * Checks validity of JSON schema built-in string format specifiers like 'date-time', 'ipv4', ...
  */
-void default_string_format_check(const std::string &format, const std::string &value);
+void JSON_SCHEMA_VALIDATOR_API default_string_format_check(const std::string &format, const std::string &value);
 
 class root_schema;
 


### PR DESCRIPTION
Seems like this macro was missing leading to linker errors on windows when linking dynamically