### PR TITLE
Update CI and fix warnings

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -37,3 +37,30 @@ jobs:
         run: cmake --build build --target all -j$(nproc)
       - name: test
         run: cd build && ctest
+  build_and_test_min_version:
+    runs-on: ubuntu-latest
+    container: ghcr.io/nlohmann/json-ci:v1.0.0
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub."
+      - run: echo "🔎 Branch name is ${{ github.ref }} and repository is ${{ github.repository }}."
+      - name: Clone nlohmann json
+        uses: actions/checkout@master
+        with:
+          repository: nlohmann/json
+          path: nlohmann-json
+          ref: v3.8.0
+      - name: Build and install nlohmann json
+        run: |
+          cd nlohmann-json
+          cmake -S . -B build
+          cmake --build build --target install -j$(nproc)
+          cd ..
+      - name: Clone json-schema-validator
+        uses: actions/checkout@v2
+      - name: cmake
+        run: cmake -S . -B build
+      - name: build
+        run: cmake --build build --target all -j$(nproc)
+      - name: test
+        run: cd build && ctest

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -6,6 +6,7 @@ on:
       - develop
       - master
       - release/*
+      - main
   pull_request:
 
 jobs:
@@ -21,7 +22,7 @@ jobs:
         with:
           repository: nlohmann/json
           path: nlohmann-json
-          ref: release/3.10.2
+          ref: v3.11.2
       - name: Build and install nlohmann json
         run: |
           cd nlohmann-json

--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -179,7 +179,7 @@ public:
 		auto fragment = new_uri.pointer();
 
 		// is there a reference looking for this unknown-keyword, which is thus no longer a unknown keyword but a schema
-		auto unresolved = file.unresolved.find(fragment);
+		auto unresolved = file.unresolved.find(fragment.to_string());
 		if (unresolved != file.unresolved.end())
 			schema::make(value, this, {}, {{new_uri}});
 		else { // no, nothing ref'd it, keep for later

--- a/src/nlohmann/json-schema.hpp
+++ b/src/nlohmann/json-schema.hpp
@@ -61,7 +61,7 @@ protected:
 
 	std::tuple<std::string, std::string, std::string, std::string, std::string> as_tuple() const
 	{
-		return std::make_tuple(urn_, scheme_, authority_, path_, identifier_ != "" ? identifier_ : pointer_);
+		return std::make_tuple(urn_, scheme_, authority_, path_, identifier_ != "" ? identifier_ : pointer_.to_string());
 	}
 
 public:
@@ -80,7 +80,7 @@ public:
 	std::string fragment() const
 	{
 		if (identifier_ == "")
-			return pointer_;
+			return pointer_.to_string();
 		else
 			return identifier_;
 	}

--- a/test/binary-validation.cpp
+++ b/test/binary-validation.cpp
@@ -163,7 +163,7 @@ int main()
 	val.set_root_schema(array_of_types_without_binary);
 	val.validate({{"something", binary}}, err);
 	EXPECT_EQ(err.failed_pointers.size(), 1);
-	EXPECT_EQ(err.failed_pointers[0], "/something");
+	EXPECT_EQ(err.failed_pointers[0].to_string(), "/something");
 	err.reset();
 
 	// check that without content callback you get exception with schema with contentEncoding or contentMeditType

--- a/test/uri.cpp
+++ b/test/uri.cpp
@@ -75,11 +75,11 @@ static void pointer_plain_name(json_uri start,
 	a = a.derive("#foo/looks_like_json/poiner/but/isnt");
 	EXPECT_EQ(a, full + " # foo/looks_like_json/poiner/but/isnt");
 	EXPECT_EQ(a.identifier(), "foo/looks_like_json/poiner/but/isnt");
-	EXPECT_EQ(a.pointer(), "");
+	EXPECT_EQ(a.pointer().to_string(), "");
 
 	a = a.derive("#/looks_like_json/poiner/and/it/is");
 	EXPECT_EQ(a, full + " # /looks_like_json/poiner/and/it/is");
-	EXPECT_EQ(a.pointer(), "/looks_like_json/poiner/and/it/is");
+	EXPECT_EQ(a.pointer().to_string(), "/looks_like_json/poiner/and/it/is");
 	EXPECT_EQ(a.identifier(), "");
 }
 


### PR DESCRIPTION
Hi @pboettch, PTAL.

This updates CI to run on main and uses the latest nlohmann-json to test.
This also adds the `to_string()` call to remove warnings.

The current tag is also very old so could we get an updated tag?