### PR TITLE
Updates conanfile.py

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -64,3 +64,20 @@ jobs:
         run: cmake --build build --target all -j$(nproc)
       - name: test
         run: cd build && ctest
+  build_conan:
+    runs-on: ubuntu-latest
+    container: ghcr.io/nlohmann/json-ci:v2.4.0
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub."
+      - run: echo "🔎 Branch name is ${{ github.ref }} and repository is ${{ github.repository }}."
+      - name: Clone json-schema-validator
+        uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: python -m pip install --upgrade conan
+      - run: conan config init
+      - run: conan profile update settings.compiler.libcxx=libstdc++11 default
+      - name: conan create package
+        run: conan create .


### PR DESCRIPTION
Adds updates to `conanfile.py` as the existing was not working anymore. 

Summary:
- Updates dependency `nlohmann_json` to v3.11.2
- Updates handling of dependency

Verified using Conan version 1.52.0 :
1. Building in repo
   ```
   mkdir build && cd build
   conan install ..
   conan build ..
   ```
   Minor remark: the test-case `cmake-install` does not work with this method. All other tests work as expected by invocation of `ctest -V`.
1. Creating package in conan cache
   ```
   conan create .
   ```
