### PR TITLE
Use find_dependency in PackageConfig file

### DIFF
--- a/nlohmann_json_schema_validatorConfig.cmake.in
+++ b/nlohmann_json_schema_validatorConfig.cmake.in
@@ -1,6 +1,7 @@
 @PACKAGE_INIT@
 
-find_package(nlohmann_json 3.8.0 REQUIRED)
+include(CMakeFindDependencyMacro)
+find_dependency(nlohmann_json)
 
 include("${CMAKE_CURRENT_LIST_DIR}/nlohmann_json_schema_validatorTargets.cmake")
 check_required_components(


### PR DESCRIPTION
This applies the vcpkg patch that replaces the direct call to `find_package` with the `find_dependency` macro.

Note that this macro does not implicitly specify a version. Like the main `CMakeLists.txt` file i've omitted it to avoid tying the config file to a specific version.

See pboettch/json-schema-validator#207