### PR TITLE
Local include for smtp-address-validator.hpp

### DIFF
--- a/src/string-format-check.cpp
+++ b/src/string-format-check.cpp
@@ -1,6 +1,6 @@
 #include <nlohmann/json-schema.hpp>
 
-#include <smtp-address-validator.hpp>
+#include "smtp-address-validator.hpp"
 
 #include <algorithm>
 #include <exception>


### PR DESCRIPTION
This makes _string-format-check.cpp_ consistent with _smtp-address-validator.cpp_.
This means that the _nlohmann_ directory itself doesn't have to be in the system search path. (The directory in which the _nlohmann_ directory is contained is much more likely to be, so e.g. `#include <nlohmann/json-schema.hpp>` is fine.) 