### PR TITLE
Fix warning with nlohmann_json/3.11.2

### DIFF
--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -255,7 +255,7 @@ public:
 		// not by a plain name fragment
 		if (uri.pointer().to_string() != "") {
 			try {
-				auto &subschema = file.unknown_keywords.at(uri.pointer()); // null is returned if not existing
+				auto &subschema = file.unknown_keywords.at(uri.pointer().to_string()); // null is returned if not existing
 				auto s = schema::make(subschema, this, {}, {{uri}});       //  A JSON Schema MUST be an object or a boolean.
 				if (s) {                                                   // nullptr if invalid schema, e.g. null
 					file.unknown_keywords.erase(uri.fragment());


### PR DESCRIPTION
In nlohmann_json/3.11.2, the mixed type comparison operators have been deprecated, so there's one more `to_string()` required to get rid of a new (since nlohmann_json/3.11.1) warning with gcc, something like this:

```
<source>: In instantiation of 'struct nlohmann::json_abi_v3_11_2::detail::is_comparable<std::less<std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>, nlohmann::json_abi_v3_11_2::json_pointer<std::__cxx11::basic_string<char> >&, void>':
<source>:3921:31:   required by substitution of 'template<class KeyType, typename std::enable_if<typename std::conditional<(typename std::conditional<(((nlohmann::json_abi_v3_11_2::detail::is_comparable<std::less<std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>, KeyType, void>::value && (!(true && std::is_same<typename std::remove_cv<typename std::remove_reference<_Tp>::type>::type, std::__cxx11::basic_string<char> >::value))) && ((! true) || std::integral_constant<bool, false>::value)) && (! nlohmann::json_abi_v3_11_2::detail::is_specialization_of<nlohmann::json_abi_v3_11_2::json_pointer, typename std::remove_cv<typename std::remove_reference<typename std::remove_cv<typename std::remove_reference<_Tp>::type>::type>::type>::type>::value)), std::integral_constant<bool, true>, std::integral_constant<bool, false> >::type::value && (! nlohmann::json_abi_v3_11_2::detail::is_json_iterator_of<nlohmann::json_abi_v3_11_2::basic_json<>, typename std::remove_cv<typename std::remove_reference<_Tp>::type>::type>::value)), std::integral_constant<bool, true>, std::integral_constant<bool, false> >::type::value, int>::type <anonymous> > const nlohmann::json_abi_v3_11_2::basic_json<>::value_type& nlohmann::json_abi_v3_11_2::basic_json<>::at(KeyType&&) const [with KeyType = nlohmann::json_abi_v3_11_2::json_pointer<std::__cxx11::basic_string<char> >&; typename std::enable_if<typename std::conditional<(typename std::conditional<(((nlohmann::json_abi_v3_11_2::detail::is_comparable<std::less<std::__cxx11::basic_string<char> >, std::__cxx11::basic_string<char>, KeyType, void>::value && (!(true && std::is_same<typename std::remove_cv<typename std::remove_reference<_Tp>::type>::type, std::__cxx11::basic_string<char> >::value))) && ((! true) || std::integral_constant<bool, false>::value)) && (! nlohmann::json_abi_v3_11_2::detail::is_specialization_of<nlohmann::json_abi_v3_11_2::json_pointer, typename std::remove_cv<typename std::remove_reference<typename std::remove_cv<typename std::remove_reference<_Tp>::type>::type>::type>::type>::value)), std::integral_constant<bool, true>, std::integral_constant<bool, false> >::type::value && (! nlohmann::json_abi_v3_11_2::detail::is_json_iterator_of<nlohmann::json_abi_v3_11_2::basic_json<>, typename std::remove_cv<typename std::remove_reference<_Tp>::type>::type>::value)), std::integral_constant<bool, true>, std::integral_constant<bool, false> >::type::value, int>::type <anonymous> = <missing>]'
<source>:24604:9:   required from here
<source>:3908:33: warning: 'nlohmann::json_abi_v3_11_2::json_pointer<RefStringType>::operator string_t() const [with RefStringType = std::__cxx11::basic_string<char>; string_t = std::__cxx11::basic_string<char>]' is deprecated: Since 3.11.0; use to_string() [-Wdeprecated-declarations]
 3908 | decltype(std::declval<Compare>()(std::declval<A>(), std::declval<B>())),
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<source>:13762:5: note: declared here
13762 |     operator string_t() const
      |     ^~~~~~~~
<source>:3909:33: warning: 'nlohmann::json_abi_v3_11_2::json_pointer<RefStringType>::operator string_t() const [with RefStringType = std::__cxx11::basic_string<char>; string_t = std::__cxx11::basic_string<char>]' is deprecated: Since 3.11.0; use to_string() [-Wdeprecated-declarations]
 3909 | decltype(std::declval<Compare>()(std::declval<B>(), std::declval<A>()))
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<source>:13762:5: note: declared here
13762 |     operator string_t() const
      |     ^~~~~~~~
<source>:3908:33: warning: 'nlohmann::json_abi_v3_11_2::json_pointer<RefStringType>::operator string_t() const [with RefStringType = std::__cxx11::basic_string<char>; string_t = std::__cxx11::basic_string<char>]' is deprecated: Since 3.11.0; use to_string() [-Wdeprecated-declarations]
 3908 | decltype(std::declval<Compare>()(std::declval<A>(), std::declval<B>())),
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<source>:13762:5: note: declared here
13762 |     operator string_t() const
      |     ^~~~~~~~
<source>:3909:33: warning: 'nlohmann::json_abi_v3_11_2::json_pointer<RefStringType>::operator string_t() const [with RefStringType = std::__cxx11::basic_string<char>; string_t = std::__cxx11::basic_string<char>]' is deprecated: Since 3.11.0; use to_string() [-Wdeprecated-declarations]
 3909 | decltype(std::declval<Compare>()(std::declval<B>(), std::declval<A>()))
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<source>:13762:5: note: declared here
13762 |     operator string_t() const
      |     ^~~~~~~~
```
