### PR TITLE
Create path with root defaults

### DIFF
--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -499,6 +499,9 @@ class type_schema : public schema
 					else_->validate(ptr, instance, patch, e);
 			}
 		}
+		if (instance.is_null()) {
+			patch.add(nlohmann::json::json_pointer{}, default_value_);
+		}
 	}
 
 public:
@@ -884,8 +887,8 @@ class boolean : public schema
 	{
 		if (!true_) { // false schema
 			// empty array
-			//switch (instance.type()) {
-			//case json::value_t::array:
+			// switch (instance.type()) {
+			// case json::value_t::array:
 			//	if (instance.size() != 0) // valid false-schema
 			//		e.error(ptr, instance, "false-schema required empty array");
 			//	return;
@@ -1067,6 +1070,11 @@ public:
 		if (attr != sch.end()) {
 			propertyNames_ = schema::make(attr.value(), root, {"propertyNames"}, uris);
 			sch.erase(attr);
+		}
+
+		attr = sch.find("default");
+		if (attr != sch.end()) {
+			set_default_value(*attr);
 		}
 	}
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,3 +73,7 @@ add_test(NAME issue-149-entry-selection COMMAND issue-149-entry-selection)
 add_executable(issue-189-default-values issue-189-default-values.cpp)
 target_link_libraries(issue-189-default-values nlohmann_json_schema_validator)
 add_test(NAME issue-189-default-values COMMAND issue-189-default-values)
+
+add_executable(issue-243-root-default-values issue-243-root-default-values.cpp)
+target_link_libraries(issue-243-root-default-values nlohmann_json_schema_validator)
+add_test(NAME issue-243-root-default-values COMMAND issue-243-root-default-values)

--- a/test/issue-243-root-default-values.cpp
+++ b/test/issue-243-root-default-values.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <nlohmann/json-schema.hpp>
+
+using nlohmann::json;
+using nlohmann::json_uri;
+using nlohmann::json_schema::json_validator;
+
+static const json root_default = R"(
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "width": {
+            "type": "integer"
+        }
+    },
+    "default": {
+        "width": 42
+    }
+})"_json;
+
+int main(void)
+{
+	json_validator validator{};
+
+	validator.set_root_schema(root_default);
+
+	{
+		json nul_json;
+		if (!nul_json.is_null()) {
+			return 1;
+		}
+
+		const auto default_patch = validator.validate(nul_json);
+
+		if (default_patch.is_null()) {
+			std::cerr << "Patch is null but should contain operation to add defaults to root" << std::endl;
+			return 1;
+		}
+
+		const auto actual = nul_json.patch(default_patch);
+		const auto expected = R"({"width": 42})"_json;
+		if (actual != expected) {
+			std::cerr << "Patch of defaults is wrong for root schema: '" << actual.dump() << "' instead of expected '" << expected.dump() << "'" << std::endl;
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Fix for #243 that creates a patch on `null` json data in case the schema defines a default value at root.