### PR TITLE
Replace the full nlohmann_json repo with a fetch_content variant.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ set(fetch_packages "")
 # TODO: Remove when bumping cmake >= 3.24
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
     FetchContent_Declare(nlohmann_json
-            GIT_REPOSITORY https://github.com/nlohmann/json
+            GIT_REPOSITORY https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent
             GIT_TAG ${JSON_FETCH_VERSION}
             FIND_PACKAGE_ARGS
             )
@@ -95,7 +95,7 @@ else ()
     if (NOT nlohmann_json_FOUND)
         # If failed fetch the desired version
         FetchContent_Declare(nlohmann_json
-                GIT_REPOSITORY https://github.com/nlohmann/json
+                GIT_REPOSITORY https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent
                 GIT_TAG ${JSON_FETCH_VERSION}
                 )
         list(APPEND fetch_packages nlohmann_json)


### PR DESCRIPTION
During the configuring of json-schema-validator, the repository nlohmann_json is fetched via the fetch_content functionality of CMake. It is a huge repository with size 180MB, which are downloaded whenever one configures CMake on an empty build directory (e.g. after deleting the build directory to clear out cached CMake variables.) The repository
https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent

only contains releases instead of all development commits and has (at the moment) size of only 830kB, which stronly cuts the download time.

This PR implements https://github.com/pboettch/json-schema-validator/issues/277.