### PR TITLE
Fix performance regression from logical combination patch discard

### DIFF
--- a/src/json-patch.hpp
+++ b/src/json-patch.hpp
@@ -28,10 +28,13 @@ public:
 	json_patch &replace(const json::json_pointer &, json value);
 	json_patch &remove(const json::json_pointer &);
 
+	json &get_json() { return j_; }
+	const json &get_json() const { return j_; }
+
 	operator json() const { return j_; }
 
 private:
-	json j_;
+	json j_ = nlohmann::json::array();
 
 	static void validateJsonPatch(json const &patch);
 };

--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -436,12 +436,12 @@ class logical_combination : public schema
 
 		for (auto &s : subschemata_) {
 			first_error_handler esub;
-			json_patch old_patch(patch);
+			auto oldPatchSize = patch.get_json().size();
 			s->validate(ptr, instance, patch, esub);
 			if (!esub)
 				count++;
 			else
-				patch = old_patch;
+				patch.get_json().get_ref<nlohmann::json::array_t &>().resize(oldPatchSize);
 
 			if (is_validate_complete(instance, ptr, e, esub, count))
 				return;


### PR DESCRIPTION
A recent fix to discard patch from invalid logical combination introduced a lot (for large json instance and/or schema) of copies to make a patch backup. On some case, this introduced up to a 100x slower validation time (I observed times from 50ms to 7s on one of my use case).

Resizing the patch object to its previous size avoid unnecessary temporary allocations from the backup object.

* I needed to expose the internal json object to be able to resize it. I'm not sure how differently we could achieve this if you don't like that.
* It also fixes the default value of an empty json_patch. I think it should be an empty array and not a null json according to the json patch schema.
* I know you mentioned in #229 that you won't accept more changes on this subject, however this is quite a big performance regression so I hope this can still be merged.
On that matter, I'm willing to spend a bit of time, after this fix, on the subject if you have ideas on how to better integrate the default values handling in the library. I think this is quite an important feature as it makes parsing a lot easier if one can put default values in a single reference place (the schema). I don't known what elements you don't like in the current design though.