### PR TITLE
Improve Conanfile for consumers of the package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,12 @@ endif ()
 #                                    Basic project definition                                   #
 ]==============================================================================================]
 
+# TODO: CMake >= 3.19 can use string(JSON VERSION GET "${METADATA}" "version") to load from JSON
+set(PROJECT_VERSION 2.2.0)
+
 # TODO: Version 3, rename the project and namespace to something more compact
 project(nlohmann_json_schema_validator
-        VERSION 2.2.0
+        VERSION ${PROJECT_VERSION}
         DESCRIPTION "Json validator for nlohmann::json library"
         HOMEPAGE_URL "https://github.com/pboettch/json-schema-validator"
         LANGUAGES CXX)


### PR DESCRIPTION
- Type 'make' to build and test the package in one go
- Fix issues with Conanfile - create a package which can be consumed by downstream Conan packages

The export_sources field of the conanfile was incorrect, preventing downstream packages from consuming this package.

I also took the liberty of making some changes to the Conanfile to make the build more "standard" and easier to work with (allowing the use of a simple Makefile to easily build & test the package).