### PR TITLE
Prefix PUBLIC_HEADER with CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(nlohmann_json_schema_validator PUBLIC
         )
 
 set_target_properties(nlohmann_json_schema_validator PROPERTIES
-        PUBLIC_HEADER nlohmann/json-schema.hpp)
+        PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/nlohmann/json-schema.hpp)
 
 # TODO: Why would this need to be if guarded?
 if (JSON_VALIDATOR_SHARED_LIBS)


### PR DESCRIPTION
This is required to install the project when using cmake FetchContent, or it will complain about the file json-schema.hpp not found (because it will use a relative path to the project that called FetchContent instead of json-schema-validator path