### PR TITLE
add support for `$defs` instead of `definitions`.

### DIFF
--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -1386,11 +1386,18 @@ std::shared_ptr<schema> schema::make(json &schema,
 			schema.erase(attr);
 		}
 
-		attr = schema.find("definitions");
-		if (attr != schema.end()) {
-			for (auto &def : attr.value().items())
-				schema::make(def.value(), root, {"definitions", def.key()}, uris);
-			schema.erase(attr);
+		auto findDefinitions = [&](const std::string &defs) -> bool {
+			attr = schema.find(defs);
+			if (attr != schema.end()) {
+				for (auto &def : attr.value().items())
+					schema::make(def.value(), root, {defs, def.key()}, uris);
+				schema.erase(attr);
+				return true;
+			}
+			return false;
+		};
+		if (!findDefinitions("definitions")) {
+			findDefinitions("$defs");
 		}
 
 		attr = schema.find("$ref");

--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -1396,8 +1396,8 @@ std::shared_ptr<schema> schema::make(json &schema,
 			}
 			return false;
 		};
-		if (!findDefinitions("definitions")) {
-			findDefinitions("$defs");
+		if (!findDefinitions("$defs")) {
+			findDefinitions("definitions");
 		}
 
 		attr = schema.find("$ref");


### PR DESCRIPTION
One of the changes for the 1020-12 schema specification (#153) is the keyword `$defs` instead of `definitions`. This PR implements that change.

With this change in place I can load the MNX schema and correctly validate MNX files against it. However, I am a newbie here, so I welcome comments on how to improve it.
