### PR TITLE
Fix compile error: implicit conversion from 'long' to 'double' may lose

### DIFF
--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -896,7 +896,7 @@ class numeric : public schema
 	bool violates_multiple_of(T x) const
 	{
 		double res = std::remainder(x, multipleOf_.second);
-		double multiple = std::fabs(x / multipleOf_.second);
+		double multiple = std::fabs(static_cast<double>(x) / multipleOf_.second);
 		if (multiple > 1) {
 			res = res / multiple;
 		}


### PR DESCRIPTION
error: implicit conversion from 'long' to 'double' may lose precision [-Werror,-Wimplicit-int-float-conversion]