### PR TITLE
Fix crash when validating null values in objects with additionalProperties

### DIFF
--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -588,9 +588,6 @@ class type_schema : public schema
 					else_->validate(ptr, instance, patch, e);
 			}
 		}
-		if (instance.is_null()) {
-			patch.add(nlohmann::json::json_pointer{}, default_value_);
-		}
 	}
 
 protected:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,3 +96,7 @@ add_test(NAME issue-255-error-message-limit-precision COMMAND issue-255-error-me
 add_executable(issue-105-verbose-combination-errors issue-105-verbose-combination-errors.cpp)
 target_link_libraries(issue-105-verbose-combination-errors nlohmann_json_schema_validator)
 add_test(NAME issue-105-verbose-combination-errors COMMAND issue-105-verbose-combination-errors)
+
+add_executable(issue-null-values-in-object issue-null-values-in-object.cpp)
+target_link_libraries(issue-null-values-in-object nlohmann_json_schema_validator)
+add_test(NAME issue-null-values-in-object COMMAND issue-null-values-in-object)

--- a/test/issue-null-values-in-object.cpp
+++ b/test/issue-null-values-in-object.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <nlohmann/json-schema.hpp>
+
+using nlohmann::json;
+using nlohmann::json_schema::json_validator;
+
+// Test: object with additionalProperties containing null value should validate
+// additionalProperties causes traversal into the object where null value triggers the bug
+static const json schema = R"(
+{
+    "properties": {
+        "x": {"type": "object", "additionalProperties": {}}
+    }
+})"_json;
+
+int main(void)
+{
+	json_validator validator{};
+	validator.set_root_schema(schema);
+
+	json instance = R"({"x": {"nested": null}})"_json;
+
+	const auto patch = validator.validate(instance);
+	const auto result = instance.patch(patch);
+
+	// null value should be preserved
+	if (!result["x"]["nested"].is_null()) {
+		std::cerr << "Failed: nested should be null, got: " << result["x"]["nested"].dump() << std::endl;
+		return 1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Remove erroneous code that added a patch with empty JSON pointer for any null instance. Null is a valid JSON value and should not trigger a patch.