### PR TITLE
Fix required property error when property has a default value

### DIFF
--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -1061,8 +1061,14 @@ class object : public schema
 			e.error(ptr, instance, "too few properties");
 
 		for (auto &r : required_)
-			if (instance.find(r) == instance.end())
+			if (instance.find(r) == instance.end()) {
+				// Skip required error if property has a default value (it will be added later)
+				auto prop = properties_.find(r);
+				if (prop != properties_.end() &&
+				    !prop->second->default_value(json::json_pointer{}, {}, e).is_null())
+					continue;
 				e.error(ptr, instance, "required property '" + r + "' not found in object");
+			}
 
 		// for each property in instance
 		for (auto &p : instance.items()) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,10 @@ target_include_directories(json-patch PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(json-patch nlohmann_json_schema_validator)
 add_test(NAME json-patch COMMAND json-patch)
 
+add_executable(issue-required-with-default issue-required-with-default.cpp)
+target_link_libraries(issue-required-with-default nlohmann_json_schema_validator)
+add_test(NAME issue-required-with-default COMMAND issue-required-with-default)
+
 # Unit test for format checker fail at schema parsing time
 add_executable(issue-117-format-error issue-117-format-error.cpp)
 target_link_libraries(issue-117-format-error nlohmann_json_schema_validator)

--- a/test/issue-required-with-default.cpp
+++ b/test/issue-required-with-default.cpp
@@ -1,0 +1,34 @@
+#include <nlohmann/json-schema.hpp>
+
+using nlohmann::json;
+using nlohmann::json_schema::json_validator;
+
+// Test: required property with default should be filled, not error
+static const json schema = R"(
+{
+    "properties": {
+        "x": {"type": "string", "default": "foo"}
+    },
+    "required": ["x"]
+})"_json;
+
+int main(void)
+{
+	json_validator validator{};
+	validator.set_root_schema(schema);
+
+	json instance = R"({})"_json;
+
+	// Use throwing error handler - validation must succeed
+	nlohmann::json_schema::basic_error_handler err;
+	const auto patch = validator.validate(instance, err);
+	if (err)
+		return 1;
+
+	const auto result = instance.patch(patch);
+
+	if (result["x"] != "foo")
+		return 1;
+
+	return 0;
+}


### PR DESCRIPTION
Skip the 'required property not found' error if the property has a default value defined, since the default will be added to the patch by the existing reverse search loop.