### PR TITLE
Fix is_address when char is unsigned

### DIFF
--- a/src/smtp-address-validator.cpp
+++ b/src/smtp-address-validator.cpp
@@ -670,11 +670,13 @@ static const short _address_eof_trans[] = {
 
 static const int address_start = 1;
 
-bool is_address(const char *p, const char *pe)
+bool is_address(const char *pc, const char *pec)
 {
 	int cs = 0;
 
-	const char *eof = pe;
+	const signed char *p = reinterpret_cast<const signed char *>(pc);
+	const signed char *pe = reinterpret_cast<const signed char *>(pec);
+	const signed char *eof = pe;
 
 	bool result = false;
 


### PR DESCRIPTION
Fixes https://github.com/pboettch/json-schema-validator/issues/375.  The issue is that, in the comparison `if (((*(p))) < (*(_mid)))`, `p` points to a `char` and `_mid` points to a `signed char`.  If `_mid` is negative, then the comparison is always false.  This PR makes all pointers explicitly point to signed values to fix the issue.