### PR TITLE
Use read-only ifstream to load the schema files in tests

### DIFF
--- a/test/JSON-Schema-Test-Suite/json-schema-test.cpp
+++ b/test/JSON-Schema-Test-Suite/json-schema-test.cpp
@@ -28,7 +28,7 @@ static void loader(const json_uri &uri, json &schema)
 	fn += uri.path();
 	std::cerr << fn << "\n";
 
-	std::fstream s(fn.c_str());
+	std::ifstream s(fn);
 	if (!s.good())
 		throw std::invalid_argument("could not open " + uri.url() + " for schema loading\n");
 

--- a/test/issue-93/issue-93.cpp
+++ b/test/issue-93/issue-93.cpp
@@ -39,7 +39,9 @@ int main(void)
 {
 	json_validator validator(loader);
 
-	std::fstream f("blueprints.schema.json");
+	std::ifstream f("blueprints.schema.json");
+	if (!f.good())
+		throw std::invalid_argument("Could not open main schema file");
 
 	json schema;
 	f >> schema;


### PR DESCRIPTION
Both were using `fstream` which opens the file for read-write, which fails if the executing user does not have write permission on the file. As the tests only read from the file, we can just open them only for reading.

One tiny character that has kept me puzzled for far longer than *`i`* care to admit publicly. :wink: