### PR TITLE
Fix exception slicing in regex format check

### DIFF
--- a/src/string-format-check.cpp
+++ b/src/string-format-check.cpp
@@ -395,7 +395,7 @@ void default_string_format_check(const std::string &format, const std::string &v
 		try {
 			REGEX_NAMESPACE::regex re(value, std::regex::ECMAScript);
 		} catch (std::exception &exception) {
-			throw exception;
+			throw;
 		}
 	} else {
 		/* yet unsupported JSON schema draft 7 built-ins */


### PR DESCRIPTION
When `format` is `"regex"`, `default_string_format_check` tries to construct a `std::regex`/`boost::regex` from the value and, if that fails, does this:

```cpp
} catch (std::exception &exception) {
    throw exception;
}
```

`throw exception;` re-throws a new object sliced to the caught variable's static type (`std::exception`), so whatever more specific exception was actually thrown (e.g. `std::regex_error`, or `boost::regex_error` when built with `JSON_SCHEMA_BOOST_REGEX`) gets discarded along with its real message and error code. The caller in json-validator.cpp just does `e.error(ptr, instance, "format-checking failed: " + ex.what())`, so the user sees the useless string "std::exception" instead of something like "Unexpected character in bracket expression."

I confirmed this by validating `{"type": "string", "format": "regex"}` against the instance `"["` (an invalid ECMAScript regex) through the actual `json_validator`: with the current code the thrown message is `format-checking failed: std::exception`; changing `throw exception;` to `throw;` (which just re-raises the original exception instead of copy-constructing a new sliced one) makes it `format-checking failed: Unexpected character in bracket expression.`

This is the same bug and same fix already discussed in #340, where it's been sitting unclaimed since December 2024.
