### PR TITLE
Use valid pointer ranges for email checks

### DIFF
--- a/src/string-format-check.cpp
+++ b/src/string-format-check.cpp
@@ -364,11 +364,11 @@ void default_string_format_check(const std::string &format, const std::string &v
 		if (!is_ascii(value)) {
 			throw std::invalid_argument(value + " contains non-ASCII values, not RFC 5321 compliant.");
 		}
-		if (!is_address(&*value.begin(), &*value.end())) {
+		if (!is_address(value.data(), value.data() + value.size())) {
 			throw std::invalid_argument(value + " is not a valid email according to RFC 5321.");
 		}
 	} else if (format == "idn-email") {
-		if (!is_address(&*value.begin(), &*value.end())) {
+		if (!is_address(value.data(), value.data() + value.size())) {
 			throw std::invalid_argument(value + " is not a valid idn-email according to RFC 6531.");
 		}
 	} else if (format == "hostname") {

--- a/test/string-format-check-test.cpp
+++ b/test/string-format-check-test.cpp
@@ -98,5 +98,12 @@ int main()
 
 	numberOfErrors += testStringFormat("uri", uriChecks);
 
+	const std::vector<std::pair<std::string, bool>> emailChecks{
+	    {"test@example.com", true},
+	    {"", false}};
+
+	numberOfErrors += testStringFormat("email", emailChecks);
+	numberOfErrors += testStringFormat("idn-email", emailChecks);
+
 	return numberOfErrors;
 }


### PR DESCRIPTION
## Summary

- Pass email input to `is_address` as the half-open pointer range `[value.data(), value.data() + value.size())`.
- Add direct valid and empty-input checks for both `email` and `idn-email`.

## Root cause

The previous code formed pointers using `&*value.begin()` and `&*value.end()`. A past-the-end iterator is not dereferenceable, and for an empty string `begin()` is past-the-end as well. The SMTP parser only needs a contiguous half-open range, which `data()` and `size()` provide without dereferencing either iterator.

## Validation

- Built and ran the string format test with GCC 14.2 and Clang 17 in C++11 mode using `-Wall -Wextra -Wshadow -Werror`.
- Exercised both format branches with a valid address and an empty string.


## How this was found

This was found while investigating an MSVC Debug-only crash in an application using generated schema validators. A generated validator called `::nlohmann::json_schema::default_string_format_check` for a `User.data.email` field declared with `format: email`.

Calling the format checker directly reproduced the same failure:

```cpp
::nlohmann::json_schema::default_string_format_check(
    "email", "alice@example.com");
```

MSVC Debug reported an `xstring(54)` assertion. The Release build did not assert, matching the behavior observed in the application and narrowing the issue down to the email format-checking path.

The implementation formed the parser range using `&*value.begin()` and `&*value.end()`. Since `end()` is a past-the-end iterator and is not dereferenceable, MSVC's checked Debug iterators detect the invalid operation. Passing the half-open range as `value.data()` and `value.data() + value.size()` avoids dereferencing either iterator and provides the range expected by `is_address`.
