### PR TITLE
Fix schema edgecases

### DIFF
--- a/src/json-patch.cpp
+++ b/src/json-patch.cpp
@@ -101,6 +101,14 @@ json_patch &json_patch::remove(const json::json_pointer &ptr)
 	return *this;
 }
 
+json_patch::saved_size json_patch::save() const {
+	return saved_size{j_.get_ref<json::array_t const &>().size()};
+}
+
+void json_patch::restore(saved_size size) {
+	j_.get_ref<json::array_t &>().resize(static_cast<json::array_t::size_type>(size));
+}
+
 void json_patch::validateJsonPatch(json const &patch)
 {
 	// static put here to have it created at the first usage of validateJsonPatch

--- a/src/json-patch.hpp
+++ b/src/json-patch.hpp
@@ -20,6 +20,8 @@ private:
 class json_patch
 {
 public:
+	enum class saved_size : json::array_t::size_type {};
+
 	json_patch() = default;
 	json_patch(json &&patch);
 	json_patch(const json &patch);
@@ -28,8 +30,8 @@ public:
 	json_patch &replace(const json::json_pointer &, json value);
 	json_patch &remove(const json::json_pointer &);
 
-	json &get_json() { return j_; }
-	const json &get_json() const { return j_; }
+	saved_size save() const;
+	void restore(saved_size size);
 
 	operator json() const { return j_; }
 

--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -371,22 +371,14 @@ public:
 namespace
 {
 
-class first_error_handler : public error_handler
+class bool_error_handler : public error_handler
 {
 public:
 	bool error_{false};
-	json::json_pointer ptr_;
-	json instance_;
-	std::string message_;
 
-	void error(const json::json_pointer &ptr, const json &instance, const std::string &message) override
+	void error(const json::json_pointer &, const json &, const std::string &) override
 	{
-		if (*this)
-			return;
 		error_ = true;
-		ptr_ = ptr;
-		instance_ = instance;
-		message_ = message;
 	}
 
 	operator bool() const { return error_; }
@@ -398,10 +390,10 @@ class logical_not : public schema
 
 	void validate(const json::json_pointer &ptr, const json &instance, json_patch &patch, error_handler &e) const final
 	{
-		first_error_handler esub;
-		subschema_->validate(ptr, instance, patch, esub);
+		bool_error_handler has_errors{};
+		subschema_->validate(ptr, instance, patch, has_errors);
 
-		if (!esub)
+		if (!has_errors)
 			e.error(ptr, instance, "the subschema has succeeded, but it is required to not validate");
 	}
 
@@ -577,10 +569,10 @@ class type_schema : public schema
 			l->validate(ptr, instance, patch, e);
 
 		if (if_) {
-			first_error_handler err;
+			bool_error_handler has_errors{};
+			if_->validate(ptr, instance, patch, has_errors);
 
-			if_->validate(ptr, instance, patch, err);
-			if (!err) {
+			if (!has_errors) {
 				if (then_)
 					then_->validate(ptr, instance, patch, e);
 			} else {
@@ -1088,10 +1080,7 @@ class object : public schema
 
 			// check additionalProperties as a last resort
 			if (!a_prop_or_pattern_matched && additionalProperties_) {
-				first_error_handler additional_prop_err;
-				additionalProperties_->validate(ptr / p.key(), p.value(), patch, additional_prop_err);
-				if (additional_prop_err)
-					e.error(ptr, instance, "validation failed for additional property '" + p.key() + "': " + additional_prop_err.message_);
+				additionalProperties_->validate(ptr / p.key(), p.value(), patch, e);
 			}
 		}
 
@@ -1252,9 +1241,9 @@ class array : public schema
 		if (contains_) {
 			bool contained = false;
 			for (auto &item : instance) {
-				first_error_handler local_e;
-				contains_->validate(ptr, item, patch, local_e);
-				if (!local_e) {
+				bool_error_handler has_errors;
+				contains_->validate(ptr, item, patch, has_errors);
+				if (!has_errors) {
 					contained = true;
 					break;
 				}

--- a/src/json-validator.cpp
+++ b/src/json-validator.cpp
@@ -390,8 +390,10 @@ class logical_not : public schema
 
 	void validate(const json::json_pointer &ptr, const json &instance, json_patch &patch, error_handler &e) const final
 	{
+		auto size = patch.save();
 		bool_error_handler has_errors{};
 		subschema_->validate(ptr, instance, patch, has_errors);
+		patch.restore(size);
 
 		if (!has_errors)
 			e.error(ptr, instance, "the subschema has succeeded, but it is required to not validate");
@@ -456,12 +458,12 @@ class logical_combination : public schema
 		for (std::size_t index = 0; index < subschemata_.size(); ++index) {
 			const std::shared_ptr<schema> &s = subschemata_[index];
 			logical_combination_error_handler esub;
-			auto oldPatchSize = patch.get_json().size();
+			auto size = patch.save();
 			s->validate(ptr, instance, patch, esub);
 			if (!esub)
 				count++;
 			else {
-				patch.get_json().get_ref<nlohmann::json::array_t &>().resize(oldPatchSize);
+				patch.restore(size);
 				esub.propagate(error_summary, "case#" + std::to_string(index) + "] ");
 			}
 
@@ -569,6 +571,7 @@ class type_schema : public schema
 			l->validate(ptr, instance, patch, e);
 
 		if (if_) {
+			auto size = patch.save();
 			bool_error_handler has_errors{};
 			if_->validate(ptr, instance, patch, has_errors);
 
@@ -576,6 +579,7 @@ class type_schema : public schema
 				if (then_)
 					then_->validate(ptr, instance, patch, e);
 			} else {
+				patch.restore(size);
 				if (else_)
 					else_->validate(ptr, instance, patch, e);
 			}
@@ -1242,11 +1246,12 @@ class array : public schema
 			bool contained = false;
 			for (auto &item : instance) {
 				bool_error_handler has_errors;
+				auto size = patch.save();
 				contains_->validate(ptr, item, patch, has_errors);
-				if (!has_errors) {
+				if (has_errors)
+					patch.restore(size);
+				else
 					contained = true;
-					break;
-				}
 			}
 			if (!contained)
 				e.error(ptr, instance, "array does not contain required element as per 'contains'");

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,3 +96,7 @@ add_test(NAME issue-255-error-message-limit-precision COMMAND issue-255-error-me
 add_executable(issue-105-verbose-combination-errors issue-105-verbose-combination-errors.cpp)
 target_link_libraries(issue-105-verbose-combination-errors nlohmann_json_schema_validator)
 add_test(NAME issue-105-verbose-combination-errors COMMAND issue-105-verbose-combination-errors)
+
+add_executable(issue-383-additional-properties issue-383-additional-properties.cpp)
+target_link_libraries(issue-383-additional-properties nlohmann_json_schema_validator)
+add_test(NAME issue-383-additional-properties COMMAND issue-383-additional-properties)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,3 +100,7 @@ add_test(NAME issue-105-verbose-combination-errors COMMAND issue-105-verbose-com
 add_executable(issue-383-additional-properties issue-383-additional-properties.cpp)
 target_link_libraries(issue-383-additional-properties nlohmann_json_schema_validator)
 add_test(NAME issue-383-additional-properties COMMAND issue-383-additional-properties)
+
+add_executable(issue-383-conditional-default issue-383-conditional-default.cpp)
+target_link_libraries(issue-383-conditional-default nlohmann_json_schema_validator)
+add_test(NAME issue-383-conditional-default COMMAND issue-383-conditional-default)

--- a/test/errors.cpp
+++ b/test/errors.cpp
@@ -97,7 +97,7 @@ int main(void)
 	EXPECT_EQ(err.failed_pointers.size(), 3);
 	EXPECT_EQ(err.failed_pointers[0].to_string(), "");
 	EXPECT_EQ(err.failed_pointers[1].to_string(), "");
-	EXPECT_EQ(err.failed_pointers[2].to_string(), "");
+	EXPECT_EQ(err.failed_pointers[2].to_string(), "/street");
 	err.reset();
 
 	validator.validate({{"age", 42}, {"name", 12}}, err); // name must be a string
@@ -110,7 +110,7 @@ int main(void)
 	                       {"name", "John"},
 	                       {"phones", {1234, "223"}},
 	                   },
-	                   err); // name must be a string
+	                   err); // items of phones must be numbers
 	EXPECT_EQ(err.failed_pointers.size(), 1);
 	EXPECT_EQ(err.failed_pointers[0].to_string(), "/phones/1");
 	err.reset();
@@ -121,9 +121,9 @@ int main(void)
 	                       {"phones", {0}},
 	                       {"post-code", 12345},
 	                   },
-	                   err); // name must be a string
+	                   err); // invalid additional property post-code
 	EXPECT_EQ(err.failed_pointers.size(), 1);
-	EXPECT_EQ(err.failed_pointers[0].to_string(), "");
+	EXPECT_EQ(err.failed_pointers[0].to_string(), "/post-code");
 	err.reset();
 
 	return error_count;

--- a/test/issue-383-additional-properties.cpp
+++ b/test/issue-383-additional-properties.cpp
@@ -1,0 +1,70 @@
+#include "nlohmann/json-schema.hpp"
+
+using nlohmann::json;
+using nlohmann::json_schema::json_validator;
+
+/*
+ * This schema describes a JSON object representing a map from strings to
+ * complex numbers, where each complex numbers is a 2-element array of
+ * numbers.
+ */
+static auto schema = json::parse(R"JSON({
+	"description": "map from from string to complex numbers",
+	"additionalProperties": {
+		"description": "complex number",
+		"type": "array",
+		"items": [
+			{
+				"description": "real part",
+				"type": "number"
+			},
+			{
+				"description": "imaginary part",
+				"type": "number"
+			}
+		]
+	}
+})JSON");
+
+/*
+ * This example contains 4 errors in total.
+ * 
+ * Additional properties had previously discarded all but the first
+ * error message from the "additionalProperties" schema validation.
+ * The value of "invalid-real-and-imaginary-part" would thus
+ * only emit an error for the invalid real part and the error
+ * for the invalid imaginary part was quietly dicarded.
+ */
+static auto example = json::parse(R"JSON({
+	"valid": [1, 2],
+	"invalid-imaginary-part": [1, "invalid"],
+	"invalid-real-part": ["invalid", 2],
+	"invalid-real-and-imaginary-part": ["invalid", "invalid"]
+})JSON");
+
+class counting_error_handler : public nlohmann::json_schema::error_handler {
+	size_t total_ = 0;
+
+public:
+	void error(const json::json_pointer &, const json &, const std::string &) override
+	{
+		total_ += 1;
+	}
+
+	size_t total() {
+		return total_;
+	}
+};
+
+int main(void)
+{
+	auto validator = json_validator(schema);
+	auto counter = counting_error_handler();
+	validator.validate(example, counter);
+
+	if (counter.total() != 4) {
+		return EXIT_FAILURE;
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/test/issue-383-conditional-default.cpp
+++ b/test/issue-383-conditional-default.cpp
@@ -1,0 +1,63 @@
+#include "nlohmann/json-schema.hpp"
+
+using nlohmann::json;
+using nlohmann::json_schema::json_validator;
+
+/*
+ * This schema describes a JSON object with two mutually exclusive
+ * properties "a" and "b" enforced through a "not" - "required"
+ * pattern. The "not"-schema matches only if both of the mutually
+ * exclusive properties are present through its "required".
+ *
+ * This schema includes an uncommon edge-case: There are default
+ * values specified in the properties of the "not"-schema as well as
+ * in the dummy "if"-schema. These should only serve as conditions
+ * for the evaluation result or the evaluation of "then"/"else"
+ * subschemas, but shouldn't contribute default values to the final
+ * default-value patch themselves.
+ */
+static auto schema = json::parse(R"JSON({
+	"type": "object",
+
+	"properties": {
+		"a": {
+			"type": "boolean"
+		},
+		"b": {
+			"type": "boolean"
+		}
+	},
+
+	"if": {
+		"required": ["a", "b"],
+		"properties": {
+			"a": {
+				"type": "boolean",
+				"default": true
+			}
+		}
+	},
+
+	"not": {
+		"required": ["a", "b"],
+		"properties": {
+			"b": {
+				"type": "boolean",
+				"default": true
+			}
+		}
+	}
+})JSON");
+
+int main(void)
+{
+	auto validator = json_validator(schema);
+	auto example = json::object();
+	auto default_patch = validator.validate(example);
+
+	if (not default_patch.empty()) {
+		return EXIT_FAILURE;
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/test/issue-70-root-schema-constructor.cpp
+++ b/test/issue-70-root-schema-constructor.cpp
@@ -90,7 +90,7 @@ int main(void)
 	EXPECT_EQ(err.failed_pointers.size(), 3);
 	EXPECT_EQ(err.failed_pointers[0].to_string(), "");
 	EXPECT_EQ(err.failed_pointers[1].to_string(), "");
-	EXPECT_EQ(err.failed_pointers[2].to_string(), "");
+	EXPECT_EQ(err.failed_pointers[2].to_string(), "/street");
 	err.reset();
 
 	validator.validate({{"age", 42}, {"name", 12}}, err); // name must be a string
@@ -103,7 +103,7 @@ int main(void)
 	                       {"name", "John"},
 	                       {"phones", {1234, "223"}},
 	                   },
-	                   err); // name must be a string
+	                   err); // items of phones must be numbers
 	EXPECT_EQ(err.failed_pointers.size(), 1);
 	EXPECT_EQ(err.failed_pointers[0].to_string(), "/phones/1");
 	err.reset();
@@ -114,9 +114,9 @@ int main(void)
 	                       {"phones", {0}},
 	                       {"post-code", 12345},
 	                   },
-	                   err); // name must be a string
+	                   err); // invalid additional property post-code
 	EXPECT_EQ(err.failed_pointers.size(), 1);
-	EXPECT_EQ(err.failed_pointers[0].to_string(), "");
+	EXPECT_EQ(err.failed_pointers[0].to_string(), "/post-code");
 	err.reset();
 
 	return error_count;


### PR DESCRIPTION
## Description

I've taken my time to look deeper into this schema-validator and noticed some edge-cases in the default value processing and error reporting.

### Multiple validation errors for "additionalProperties"

I commonly use the `additionalProperties` directive to specify a schema for a string-value-map-style objects. The validator will only output the first validation error encountered in any validated property. I'd compare this case to the validation of array items where we are not limited to a single error.

Let's assume the following schema:

```json
{
  "type": "object",
  "additionalProperties": {
    "type": "array",
    "items": [
      { "const": "A" },
      { "const": "B" }
    ] 
  }
}
```

If we now validate e.g. `{ "some_key": [1, 2] }` we will only see an error reported for the first element of the array. The diagnostic for the second element is discarded by the validator.

### Failed conditions can insert default values

Condition-type schema directives like `if`, `not` and `contains` which apply a subschema that is expected to fail even if validation ulimately succeeds need to ensure that their subschema will not introduce default values into the default value patch. I've now implemented this in a way that disregards default values even if the schema validates successfully for `if`, `not` and `contains` in the same way that was already done for `anyOf` and `oneOf`.

### Error messages for trivial false-schemas

A common pattern used to deny unknown properties on object schemas or to deny unknown additional items in tuple-style array schemas is to set `additionalProperties` or `additionalItems` to `false`. This indicates that only a closed-set of indices or properties are accepted here.

The current message of `validation failed for additional property '...': instance invalid as per false-schema` doesn't quite sit right with me, so I'm now reporting `found unexpected property "..." in object` or `found unexpected index ... in array`.

### Broken default values

I'd also like to refer to #370 which fixes an urgent problem with the way default values are processed in this library.

